### PR TITLE
chore: Add .editorconfig and fix inlined expressions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# https://editorconfig.org/
+# This configuration is used by ktlint when spotless invokes it
+
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ktlint_function_naming_ignore_when_annotated_with = Composable, Test
+ktlint_standard_backing-property-naming = disabled
+ktlint_standard_binary-expression-wrapping = disabled
+ktlint_standard_chain-method-continuation = disabled
+ktlint_standard_class-signature = disabled
+ktlint_standard_condition-wrapping = disabled
+ktlint_standard_function-expression-body = disabled
+ktlint_standard_function-literal = disabled
+ktlint_standard_function-type-modifier-spacing = disabled
+ktlint_standard_multiline-loop = disabled
+ktlint_standard_function-signature = disabled

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
@@ -95,11 +95,14 @@ open class Component internal constructor(
         }
     }
 
-    inline fun <reified T : Any> get(qualifier: Qualifier? = null): T = get(T::class.java, qualifier)
+    inline fun <reified T : Any> get(qualifier: Qualifier? = null): T =
+        get(T::class.java, qualifier)
 
-    open fun <T : Any> lazyOf(type: Class<T>, qualifier: Qualifier? = null): Lazy<T> = lazy(LazyThreadSafetyMode.NONE) { get(type, qualifier) }
+    open fun <T : Any> lazyOf(type: Class<T>, qualifier: Qualifier? = null): Lazy<T> =
+        lazy(LazyThreadSafetyMode.NONE) { get(type, qualifier) }
 
-    inline fun <reified T : Any> lazyOf(qualifier: Qualifier? = null): Lazy<T> = lazyOf(T::class.java, qualifier)
+    inline fun <reified T : Any> lazyOf(qualifier: Qualifier? = null): Lazy<T> =
+        lazyOf(T::class.java, qualifier)
 
     private object DefaultQualifier
 }

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
@@ -55,7 +55,8 @@ object Stitch {
     }
 
     @PublishedApi
-    internal inline fun <reified T : Any> componentFor(qualifier: Qualifier? = null): Component = component(Signature(T::class.java, qualifier))
+    internal inline fun <reified T : Any> componentFor(qualifier: Qualifier? = null): Component =
+        component(Signature(T::class.java, qualifier))
 
     @PublishedApi
     internal fun component(signature: Signature): Component {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/engine/Plan.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/engine/Plan.kt
@@ -26,7 +26,8 @@ internal object PlanCache {
 
     private val cache = ConcurrentHashMap<ComponentSignature, Plan>()
 
-    fun computeIfAbsent(componentSignature: ComponentSignature, loader: () -> Plan): Plan = cache.computeIfAbsentCompat(componentSignature) { loader() }
+    fun computeIfAbsent(componentSignature: ComponentSignature, loader: () -> Plan): Plan =
+        cache.computeIfAbsentCompat(componentSignature) { loader() }
 
     fun clear() = cache.clear()
 }

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/CycleException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/CycleException.kt
@@ -18,7 +18,6 @@ package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.engine.Signature
 
-class CycleException internal constructor(path: List<Signature>) :
-    IllegalStateException(
-        "Dependency cycle detected: " + path.joinToString(" -> ") { it.toString() },
-    )
+class CycleException internal constructor(path: List<Signature>) : IllegalStateException(
+    "Dependency cycle detected: " + path.joinToString(" -> ") { it.toString() },
+)

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/MissingBindingException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/MissingBindingException.kt
@@ -22,7 +22,8 @@ class MissingBindingException(msg: String) : IllegalStateException(msg) {
 
     companion object {
 
-        fun missingType(type: Class<*>) = MissingBindingException("No bindings for type ${type.name}")
+        fun missingType(type: Class<*>) =
+            MissingBindingException("No bindings for type ${type.name}")
 
         fun missingQualifier(
             type: Class<*>,


### PR DESCRIPTION
Summary

Add a repository-level `.editorconfig` and fix inlined expressions

Closes #3