### PR TITLE
feat: Add registration-time eager warmup with module override

### DIFF
--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -1,8 +1,7 @@
 public final class com/harrytmthy/stitch/api/Binder {
-	public fun <init> ()V
-	public final fun bind (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;Lkotlin/jvm/functions/Function1;)V
-	public final fun include ([Lcom/harrytmthy/stitch/api/Module;)V
-	public final fun module (Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Z)V
+	public final fun factory (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;)V
+	public final fun singleton (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ZLkotlin/jvm/functions/Function1;)V
 }
 
 public class com/harrytmthy/stitch/api/Component {
@@ -12,12 +11,15 @@ public class com/harrytmthy/stitch/api/Component {
 	public static synthetic fun lazyOf$default (Lcom/harrytmthy/stitch/api/Component;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ILjava/lang/Object;)Lkotlin/Lazy;
 }
 
-public abstract interface class com/harrytmthy/stitch/api/Module {
-	public abstract fun register (Lcom/harrytmthy/stitch/api/Binder;)V
+public abstract class com/harrytmthy/stitch/api/Module {
+	public fun <init> (Z)V
+	public final fun getBinder ()Lcom/harrytmthy/stitch/api/Binder;
+	public abstract fun register ()V
 }
 
 public final class com/harrytmthy/stitch/api/ModuleKt {
-	public static final fun module (Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Module;
+	public static final fun module (ZLkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Module;
+	public static synthetic fun module$default (ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/harrytmthy/stitch/api/Module;
 }
 
 public final class com/harrytmthy/stitch/api/Named : com/harrytmthy/stitch/api/Qualifier {
@@ -56,26 +58,12 @@ public final class com/harrytmthy/stitch/api/Scope : java/lang/Enum {
 
 public final class com/harrytmthy/stitch/api/Stitch {
 	public static final field INSTANCE Lcom/harrytmthy/stitch/api/Stitch;
-	public final fun component (Lcom/harrytmthy/stitch/engine/Signature;)Lcom/harrytmthy/stitch/api/Component;
-	public final fun getEagerWarmup ()Z
+	public final fun get (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;)Ljava/lang/Object;
+	public static synthetic fun get$default (Lcom/harrytmthy/stitch/api/Stitch;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getRoot ()Lcom/harrytmthy/stitch/api/Component;
 	public final fun register ([Lcom/harrytmthy/stitch/api/Module;)V
-	public final fun setEagerWarmup (Z)V
 	public final fun setRoot (Lcom/harrytmthy/stitch/api/Component;)V
 	public final fun unregister ()V
-}
-
-public final class com/harrytmthy/stitch/engine/Signature {
-	public fun <init> (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;)V
-	public final fun component1 ()Ljava/lang/Class;
-	public final fun component2 ()Lcom/harrytmthy/stitch/api/Qualifier;
-	public final fun copy (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;)Lcom/harrytmthy/stitch/engine/Signature;
-	public static synthetic fun copy$default (Lcom/harrytmthy/stitch/engine/Signature;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ILjava/lang/Object;)Lcom/harrytmthy/stitch/engine/Signature;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getQualifier ()Lcom/harrytmthy/stitch/api/Qualifier;
-	public final fun getType ()Ljava/lang/Class;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/harrytmthy/stitch/exception/CycleException : java/lang/IllegalStateException {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Module.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Module.kt
@@ -16,12 +16,17 @@
 
 package com.harrytmthy.stitch.api
 
-interface Module {
-    fun register(binder: Binder)
+abstract class Module(overrideEager: Boolean) {
+
+    @PublishedApi
+    internal val binder = Binder(overrideEager)
+
+    abstract fun register()
 }
 
-inline fun module(crossinline block: Binder.() -> Unit): Module = object : Module {
-    override fun register(binder: Binder) {
-        block(binder)
+inline fun module(overrideEager: Boolean = false, crossinline block: Binder.() -> Unit): Module =
+    object : Module(overrideEager) {
+        override fun register() {
+            block(binder)
+        }
     }
-}

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/engine/Node.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/engine/Node.kt
@@ -24,11 +24,12 @@ import com.harrytmthy.stitch.internal.TraceResult
 internal class Node(
     val type: Class<*>,
     val qualifier: Qualifier?,
-    @Volatile private var dependencies: List<Signature>?,
-    val factory: Factory,
     val scope: Scope,
+    val factory: Factory,
     private val tracer: (Factory) -> TraceResult,
 ) {
+
+    @Volatile private var dependencies: List<Signature>? = null
 
     @Volatile
     var prebuilt: Any? = null

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/engine/Plan.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/engine/Plan.kt
@@ -32,7 +32,6 @@ internal object PlanCache {
     fun clear() = cache.clear()
 }
 
-@PublishedApi
 internal data class Signature(val type: Class<*>, val qualifier: Qualifier?) {
 
     override fun toString(): String = "${type.simpleName}[${qualifier ?: "<default>"}]"


### PR DESCRIPTION
### Summary

- Introduce registration-time eager warmup for singletons with a module-level override.
- Remove global eager.

Closes #5