### PR TITLE
feat: Implement alias via chainable binding

### DIFF
--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -1,7 +1,13 @@
 public final class com/harrytmthy/stitch/api/Binder {
 	public fun <init> (Z)V
-	public final fun factory (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;)V
-	public final fun singleton (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ZLkotlin/jvm/functions/Function1;)V
+	public final fun factory (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Binder$BindingChain;
+	public static synthetic fun factory$default (Lcom/harrytmthy/stitch/api/Binder;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/harrytmthy/stitch/api/Binder$BindingChain;
+	public final fun singleton (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ZLkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Binder$BindingChain;
+	public static synthetic fun singleton$default (Lcom/harrytmthy/stitch/api/Binder;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/harrytmthy/stitch/api/Binder$BindingChain;
+}
+
+public final class com/harrytmthy/stitch/api/Binder$BindingChain {
+	public final fun bind (Ljava/lang/Class;)Lcom/harrytmthy/stitch/api/Binder$BindingChain;
 }
 
 public class com/harrytmthy/stitch/api/Component {

--- a/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/TestFixtures.kt
+++ b/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/TestFixtures.kt
@@ -19,6 +19,10 @@ package com.harrytmthy.stitch
 interface Repo
 class RepoImpl : Repo
 
+interface Auditable
+
+class DualRepo : Repo, Auditable
+
 class Logger
 class Dao(val logger: Logger)
 


### PR DESCRIPTION
### Summary

Implements chainable alias binding support in Stitch, enabling `.bind<T>()` chaining for both singletons and factories. This feature improves ergonomics and parity with Koin while maintaining zero overhead on hot paths.

### Implementation Details

- Added `Binder.BindingChain` class with `bind<T>()` for registering type aliases.
- Introduced `registerAlias(aliasType, target)` with "family mapping" mechanism to ensure all aliases share the same definition map.
- Updated `Component.get()` to handle canonical-key cache revalidation, ensuring singleton caching consistency across aliases.
- Ensured alias families respect qualifiers, scope rules, and eager warmup behavior.
- Added comprehensive unit tests for alias resolution, qualifiers, caching, conflicts, and unregister hygiene.
- Benchmarks confirm <3% regression in cold registration and unchanged warm performance, with Stitch remaining 5-17× faster than Koin.

Closes #7