### PR TITLE
feat(scope): Add context-aware resolution and multi-scope binding support

### DIFF
--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -15,8 +15,8 @@ public final class com/harrytmthy/stitch/api/Binder$BindingChain {
 public final class com/harrytmthy/stitch/api/Component {
 	public final fun get (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcom/harrytmthy/stitch/api/Component;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun lazyOf (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;)Lkotlin/Lazy;
-	public static synthetic fun lazyOf$default (Lcom/harrytmthy/stitch/api/Component;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ILjava/lang/Object;)Lkotlin/Lazy;
+	public final fun lazyOf (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Lkotlin/Lazy;
+	public static synthetic fun lazyOf$default (Lcom/harrytmthy/stitch/api/Component;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Lkotlin/Lazy;
 }
 
 public final class com/harrytmthy/stitch/api/DefinitionType : java/lang/Enum {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Scope.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Scope.kt
@@ -17,6 +17,7 @@
 package com.harrytmthy.stitch.api
 
 import com.harrytmthy.stitch.exception.ScopeClosedException
+import com.harrytmthy.stitch.internal.Registry
 import com.harrytmthy.stitch.internal.computeIfAbsentCompat
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -32,7 +33,7 @@ class Scope internal constructor(internal val id: Int, internal val reference: S
 
     fun close() {
         open.set(false)
-        Stitch.removeScope(id)
+        Registry.scoped.remove(id)
     }
 
     internal fun isOpen(): Boolean = open.get()

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Registry.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Registry.kt
@@ -17,6 +17,7 @@
 package com.harrytmthy.stitch.internal
 
 import com.harrytmthy.stitch.api.Qualifier
+import com.harrytmthy.stitch.api.ScopeRef
 import java.util.IdentityHashMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -25,7 +26,19 @@ internal object Registry {
 
     val definitions = IdentityHashMap<Class<*>, MutableMap<Qualifier?, Node>>()
 
+    val scopedDefinitions = IdentityHashMap<Class<*>, MutableMap<Qualifier?, MutableMap<ScopeRef, Node>>>()
+
     val singletons = ConcurrentHashMap<Class<*>, ConcurrentHashMap<Any, Any>>()
 
+    val scoped = ConcurrentHashMap<Int, ConcurrentHashMap<Class<*>, ConcurrentHashMap<Any, Any>>>()
+
     val version = AtomicInteger(0)
+
+    fun clear() {
+        definitions.clear()
+        scopedDefinitions.clear()
+        singletons.clear()
+        scoped.clear()
+        version.set(0)
+    }
 }

--- a/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/TestFixtures.kt
+++ b/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/TestFixtures.kt
@@ -18,6 +18,7 @@ package com.harrytmthy.stitch
 
 interface Repo
 class RepoImpl : Repo
+class FetchUseCase(val repo: Repo)
 
 interface Auditable
 
@@ -25,6 +26,7 @@ class DualRepo : Repo, Auditable
 
 class Logger
 class Dao(val logger: Logger)
+class LoadUseCase(val dao: Dao)
 
 class NeedsMissing(val repo: Repo) // used to trigger MissingBindingException
 


### PR DESCRIPTION
### Summary

Implements context-aware scoped resolution and support for identical bindings across multiple scopes, and unifies scoped instance storage under `Registry` to improve cleanup hygiene.

### Implementation Details

- Added thread-local `ScopeContext` inside `Component` to automatically propagate the active scope during factory evaluation.
- Enhanced `Registry` with `scopedDefinitions` and `scoped` maps to track scoped nodes and instances per `ScopeRef`.
- Updated `lookupNode()` to resolve scoped families first, then fall back to global definitions.
- Simplified cleanup via `Registry.clear()` and removed redundant `removeScope()` from `Component` and `Stitch`.

Closes #13