### PR TITLE
feat(api): Add scoped getters and global injections + minor cleanups

### DIFF
--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -81,6 +81,8 @@ public final class com/harrytmthy/stitch/api/Stitch {
 	public static final field INSTANCE Lcom/harrytmthy/stitch/api/Stitch;
 	public final fun get (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcom/harrytmthy/stitch/api/Stitch;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun inject (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Lkotlin/Lazy;
+	public static synthetic fun inject$default (Lcom/harrytmthy/stitch/api/Stitch;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Lkotlin/Lazy;
 	public final fun register ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregister ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregisterAll ()V

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
@@ -113,21 +113,23 @@ class Component internal constructor(
         }
     }
 
-    inline fun <reified T : Any> get(
+    inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
+        get(T::class.java, qualifier, scope)
+
+    inline fun <reified T : Any> lazyOf(
         qualifier: Qualifier? = null,
         scope: Scope? = null,
-    ): T = get(T::class.java, qualifier, scope)
+    ): Lazy<T> {
+        return lazyOf(T::class.java, qualifier, scope)
+    }
 
     fun <T : Any> lazyOf(
         type: Class<T>,
         qualifier: Qualifier? = null,
         scope: Scope? = null,
-    ): Lazy<T> = lazy(LazyThreadSafetyMode.NONE) { get(type, qualifier, scope) }
-
-    inline fun <reified T : Any> lazyOf(
-        qualifier: Qualifier? = null,
-        scope: Scope? = null,
-    ): Lazy<T> = lazyOf(T::class.java, qualifier, scope)
+    ): Lazy<T> {
+        return lazy(LazyThreadSafetyMode.NONE) { get(type, qualifier, scope) }
+    }
 
     internal fun clear() {
         resolutionStack.remove()

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Module.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Module.kt
@@ -17,7 +17,6 @@
 package com.harrytmthy.stitch.api
 
 import com.harrytmthy.stitch.internal.DefinitionType
-import com.harrytmthy.stitch.internal.Factory
 import com.harrytmthy.stitch.internal.Node
 import com.harrytmthy.stitch.internal.Registry
 
@@ -99,7 +98,7 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
             qualifier = qualifier,
             scopeRef = null,
             definitionType = definitionType,
-            factory = factory as Factory,
+            factory = factory,
             onBind = ::registerAlias,
         )
         val inner = Registry.definitions.getOrPut(type) { HashMap() }
@@ -121,7 +120,7 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
             qualifier = qualifier,
             scopeRef = scopeRef,
             definitionType = DefinitionType.Scoped,
-            factory = factory as Factory,
+            factory = factory,
             onBind = ::registerAlias,
         )
         val scopeRefByQualifier = Registry.scopedDefinitions.getOrPut(type) { HashMap() }
@@ -156,6 +155,5 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
     internal fun getRegisteredEagerNodes(): ArrayList<Node> = registeredEagerNodes
 }
 
-fun module(forceEager: Boolean = false, onRegister: Module.() -> Unit): Module {
-    return Module(forceEager, onRegister)
-}
+fun module(forceEager: Boolean = false, onRegister: Module.() -> Unit): Module =
+    Module(forceEager, onRegister)

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Scope.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Scope.kt
@@ -36,10 +36,13 @@ class Scope internal constructor(internal val id: Int, internal val reference: S
         ScopeRef.getScopeIds(reference)?.remove(id)
     }
 
-    internal fun isOpen(): Boolean = open.get()
+    inline fun <reified T : Any> get(qualifier: Qualifier? = null): T =
+        Stitch.get(qualifier, scope = this)
 
     inline fun <reified T : Any> inject(qualifier: Qualifier? = null): Lazy<T> =
-        lazy(LazyThreadSafetyMode.NONE) { Stitch.get<T>(qualifier, scope = this) }
+        Stitch.inject(qualifier, scope = this)
+
+    internal fun isOpen(): Boolean = open.get()
 }
 
 @JvmInline

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
@@ -69,6 +69,21 @@ object Stitch {
     fun <T : Any> get(type: Class<T>, qualifier: Qualifier? = null, scope: Scope? = null): T =
         component.get(type, qualifier, scope)
 
+    inline fun <reified T : Any> inject(
+        qualifier: Qualifier? = null,
+        scope: Scope? = null,
+    ): Lazy<T> {
+        return inject(T::class.java, qualifier, scope)
+    }
+
+    fun <T : Any> inject(
+        type: Class<T>,
+        qualifier: Qualifier? = null,
+        scope: Scope? = null,
+    ): Lazy<T> {
+        return component.lazyOf(type, qualifier, scope)
+    }
+
     internal fun lookupNode(type: Class<*>, qualifier: Qualifier?, scopeRef: ScopeRef?): Node {
         Registry.scopedDefinitions[type]?.get(qualifier)?.get(scopeRef)?.let { return it }
         val inner = Registry.definitions[type] ?: throw MissingBindingException.missingType(type)

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
@@ -17,6 +17,7 @@
 package com.harrytmthy.stitch.internal
 
 import com.harrytmthy.stitch.api.Bindable
+import com.harrytmthy.stitch.api.Component
 import com.harrytmthy.stitch.api.Qualifier
 import com.harrytmthy.stitch.api.ScopeRef
 
@@ -25,7 +26,7 @@ internal class Node(
     val qualifier: Qualifier?,
     val scopeRef: ScopeRef?,
     val definitionType: DefinitionType,
-    val factory: Factory,
+    val factory: (Component) -> Any,
     val onBind: (Class<*>, Node) -> Unit,
 ) : Bindable {
 

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Util.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Util.kt
@@ -16,10 +16,7 @@
 
 package com.harrytmthy.stitch.internal
 
-import com.harrytmthy.stitch.api.Component
 import java.util.concurrent.ConcurrentHashMap
-
-internal typealias Factory = (Component) -> Any
 
 internal inline fun <K, V> ConcurrentHashMap<K, V>.computeIfAbsentCompat(
     key: K,


### PR DESCRIPTION
### Summary

Unifies `Stitch` and `Scope` ergonomics by adding eager scoped getters and global lazy injections, ensuring consistency between global and scoped access patterns.

### Implementation Details

- Added `Scope.get<T>()` delegating to `Stitch.get()` with scope context.
- Added `Stitch.inject<T>()` delegating to `Component.lazyOf()`.
- Removed unused internal `Factory` typealias from `Node.kt`.

Closes #23