### PR TITLE
refactor(api): Consolidate public reified APIs via @PublishedApi internals

### DIFF
--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -3,20 +3,12 @@ public abstract interface class com/harrytmthy/stitch/api/Bindable {
 }
 
 public final class com/harrytmthy/stitch/api/Component {
-	public final fun get (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcom/harrytmthy/stitch/api/Component;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun lazyOf (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Lkotlin/Lazy;
-	public static synthetic fun lazyOf$default (Lcom/harrytmthy/stitch/api/Component;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Lkotlin/Lazy;
+	public final fun getInternal (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
 }
 
 public final class com/harrytmthy/stitch/api/Module {
 	public fun <init> (ZLkotlin/jvm/functions/Function1;)V
-	public final fun factory (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
-	public static synthetic fun factory$default (Lcom/harrytmthy/stitch/api/Module;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/harrytmthy/stitch/api/Bindable;
-	public final fun scoped-OHUMBuI (Ljava/lang/String;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
-	public static synthetic fun scoped-OHUMBuI$default (Lcom/harrytmthy/stitch/api/Module;Ljava/lang/String;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/harrytmthy/stitch/api/Bindable;
-	public final fun singleton (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ZLkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
-	public static synthetic fun singleton$default (Lcom/harrytmthy/stitch/api/Module;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/harrytmthy/stitch/api/Bindable;
+	public final fun define-z0zhSdE (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
 }
 
 public final class com/harrytmthy/stitch/api/ModuleKt {
@@ -79,10 +71,7 @@ public final class com/harrytmthy/stitch/api/ScopeRef$Companion {
 
 public final class com/harrytmthy/stitch/api/Stitch {
 	public static final field INSTANCE Lcom/harrytmthy/stitch/api/Stitch;
-	public final fun get (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcom/harrytmthy/stitch/api/Stitch;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun inject (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Lkotlin/Lazy;
-	public static synthetic fun inject$default (Lcom/harrytmthy/stitch/api/Stitch;Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;ILjava/lang/Object;)Lkotlin/Lazy;
+	public final fun getInternal (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
 	public final fun register ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregister ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregisterAll ()V
@@ -104,5 +93,14 @@ public final class com/harrytmthy/stitch/exception/ScopeClosedException : com/ha
 }
 
 public final class com/harrytmthy/stitch/exception/WrongScopeException : com/harrytmthy/stitch/exception/GetFailedException {
+}
+
+public final class com/harrytmthy/stitch/internal/DefinitionType : java/lang/Enum {
+	public static final field Factory Lcom/harrytmthy/stitch/internal/DefinitionType;
+	public static final field Scoped Lcom/harrytmthy/stitch/internal/DefinitionType;
+	public static final field Singleton Lcom/harrytmthy/stitch/internal/DefinitionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/harrytmthy/stitch/internal/DefinitionType;
+	public static fun values ()[Lcom/harrytmthy/stitch/internal/DefinitionType;
 }
 

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
@@ -35,8 +35,19 @@ class Component internal constructor(
 
     private val scopeContext = threadLocal { ScopeContext() }
 
+    inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
+        getInternal(T::class.java, qualifier, scope)
+
+    inline fun <reified T : Any> lazyOf(
+        qualifier: Qualifier? = null,
+        scope: Scope? = null,
+    ): Lazy<T> {
+        return lazy(LazyThreadSafetyMode.NONE) { get(qualifier, scope) }
+    }
+
+    @PublishedApi
     @Suppress("UNCHECKED_CAST")
-    fun <T : Any> get(type: Class<T>, qualifier: Qualifier?, scope: Scope? = null): T {
+    internal fun <T : Any> getInternal(type: Class<T>, qualifier: Qualifier?, scope: Scope?): T {
         val qualifierKey = qualifier ?: DefaultQualifier
         val scopeContext = scopeContext.get()
         val effectiveScope = scope ?: scopeContext.scope
@@ -111,24 +122,6 @@ class Component internal constructor(
         } finally {
             resolving.exit()
         }
-    }
-
-    inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
-        get(T::class.java, qualifier, scope)
-
-    inline fun <reified T : Any> lazyOf(
-        qualifier: Qualifier? = null,
-        scope: Scope? = null,
-    ): Lazy<T> {
-        return lazyOf(T::class.java, qualifier, scope)
-    }
-
-    fun <T : Any> lazyOf(
-        type: Class<T>,
-        qualifier: Qualifier? = null,
-        scope: Scope? = null,
-    ): Lazy<T> {
-        return lazy(LazyThreadSafetyMode.NONE) { get(type, qualifier, scope) }
     }
 
     internal fun clear() {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
@@ -42,7 +42,7 @@ object Stitch {
 
     private fun warmUp(nodes: List<Node>) {
         for (node in nodes) {
-            component.get(node.type, node.qualifier)
+            component.getInternal(node.type, node.qualifier, scope = null)
         }
     }
 
@@ -64,25 +64,18 @@ object Stitch {
     }
 
     inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
-        get(T::class.java, qualifier, scope)
-
-    fun <T : Any> get(type: Class<T>, qualifier: Qualifier? = null, scope: Scope? = null): T =
-        component.get(type, qualifier, scope)
+        getInternal(T::class.java, qualifier, scope)
 
     inline fun <reified T : Any> inject(
         qualifier: Qualifier? = null,
         scope: Scope? = null,
     ): Lazy<T> {
-        return inject(T::class.java, qualifier, scope)
+        return lazy(LazyThreadSafetyMode.NONE) { getInternal(T::class.java, qualifier, scope) }
     }
 
-    fun <T : Any> inject(
-        type: Class<T>,
-        qualifier: Qualifier? = null,
-        scope: Scope? = null,
-    ): Lazy<T> {
-        return component.lazyOf(type, qualifier, scope)
-    }
+    @PublishedApi
+    internal fun <T : Any> getInternal(type: Class<T>, qualifier: Qualifier?, scope: Scope?): T =
+        component.getInternal(type, qualifier, scope)
 
     internal fun lookupNode(type: Class<*>, qualifier: Qualifier?, scopeRef: ScopeRef?): Node {
         Registry.scopedDefinitions[type]?.get(qualifier)?.get(scopeRef)?.let { return it }
@@ -92,3 +85,6 @@ object Stitch {
         }
     }
 }
+
+inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
+    Stitch.get(qualifier, scope)

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/DefinitionType.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/DefinitionType.kt
@@ -16,6 +16,7 @@
 
 package com.harrytmthy.stitch.internal
 
+@PublishedApi
 internal enum class DefinitionType {
 
     Singleton,

--- a/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/StitchTest.kt
+++ b/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/StitchTest.kt
@@ -217,7 +217,7 @@ class StitchTest {
                 Bar()
             }
             singleton {
-                val barLazy: Lazy<Bar> = lazyOf(Bar::class.java, null)
+                val barLazy: Lazy<Bar> = lazyOf(scope = null)
                 singletonBuilds++
                 UsesLazyFactory(barLazy)
             }


### PR DESCRIPTION
### Summary

This PR refactors the public API to expose only reified functions. All internal logic is consolidated under a single `@PublishedApi internal` function to duplication and binary size.

Closes #25