### PR TITLE
feat(di): Add @Binds aliases for implementation types

### DIFF
--- a/app/src/main/java/com/harrytmthy/stitch/MainActivity.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/MainActivity.kt
@@ -22,11 +22,17 @@ class MainActivity : AppCompatActivity() {
     lateinit var userRepository: UserRepository
 
     @Inject
+    lateinit var userReader: UserReader
+
+    @Inject
     lateinit var userRepositoryImpl: UserRepositoryImpl
 
     @Inject
     @Named("baseUrl")
     lateinit var baseUrl: String
+
+    @Inject
+    lateinit var processor: Processor
 
     @Inject
     lateinit var cacheService: CacheService
@@ -58,11 +64,16 @@ class MainActivity : AppCompatActivity() {
         // Singleton objects
         check(logger === Stitch.get<Logger>())
         check(userRepository === userRepositoryImpl)
+        check(userReader === userRepository)
+        check(userReader === userRepositoryImpl)
+        check(Stitch.get<UserReader>() === Stitch.get<UserRepository>())
         check(userRepositoryImpl.logger === logger)
         check(viewModel.repository === Stitch.get<UserRepository>())
         check(viewModel.cache === cacheService)
         check(cacheService === Stitch.get<CacheService>())
+        check(processor === complexService)
         check(complexService.cache === cacheService)
+        check(Stitch.get<Processor>() === Stitch.get<ComplexService>())
         check(baseUrl === Stitch.get<String>(named("baseUrl")))
 
         // Factory objects

--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Binds.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Binds.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Declares type aliases for dependency bindings without duplicating singleton instances.
+ *
+ * This annotation enables binding an implementation to one or more supertypes (interfaces/abstract classes)
+ * while maintaining a single canonical instance. This is useful for:
+ * - Interface implementation bindings (Dagger parity)
+ * - Multiple interface implementations
+ * - Avoiding duplicate singleton fields/locks
+ *
+ * **Method-level usage (in interface/abstract modules):**
+ * ```
+ * @Module
+ * interface NetworkModule {
+ *     @Binds
+ *     fun bindRepository(impl: UserRepositoryImpl): UserRepository
+ * }
+ * ```
+ *
+ * **Class-level usage (on @Inject classes):**
+ * ```
+ * @Binds(aliases = [UserRepository::class, UserReader::class])
+ * @Singleton
+ * class UserRepositoryImpl @Inject constructor() : UserRepository, UserReader
+ * ```
+ *
+ * **Method-level on @Provides (chaining):**
+ * ```
+ * @Module
+ * class AppModule {
+ *     @Provides
+ *     @Singleton
+ *     @Binds(aliases = [Service::class])
+ *     fun provideNetworkService(): NetworkService = NetworkServiceImpl()
+ * }
+ * ```
+ *
+ * @property aliases Additional supertypes to bind this implementation to.
+ *                   For method-level @Binds, the return type is automatically included.
+ *                   For class-level @Binds, these are the ONLY aliases created.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class Binds(val aliases: Array<KClass<*>> = [])

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -26,6 +26,7 @@ import com.google.devtools.ksp.symbol.KSType
 data class ModuleInfo(
     val declaration: KSClassDeclaration,
     val provides: List<ProvidesInfo>,
+    val binds: List<BindsInfo>,
 )
 
 /**
@@ -35,6 +36,22 @@ data class ProvidesInfo(
     val declaration: KSFunctionDeclaration,
     val returnType: KSType,
     val parameters: List<ParameterInfo>,
+    val isSingleton: Boolean,
+    val qualifier: QualifierInfo?,
+    val aliases: List<KSType> = emptyList(),
+)
+
+/**
+ * Represents a @Binds method in an interface/abstract module.
+ *
+ * @Binds methods declare type bindings without providing implementation.
+ * They must be abstract, take exactly one parameter (the implementation),
+ * and return a supertype (the alias).
+ */
+data class BindsInfo(
+    val declaration: KSFunctionDeclaration,
+    val implementationType: KSType,
+    val aliasType: KSType,
     val isSingleton: Boolean,
     val qualifier: QualifierInfo?,
 )
@@ -62,6 +79,7 @@ sealed class QualifierInfo {
  * For @Provides methods: all dependencies are in [dependencies]
  * For @Inject constructors: [dependencies] = constructor params + injectable fields,
  *                            [injectableFields] contains field-specific info for code generation
+ * For @Binds: [type] is the canonical implementation type, [aliases] contains supertypes
  */
 data class DependencyNode(
     val providerModule: KSClassDeclaration,
@@ -71,6 +89,7 @@ data class DependencyNode(
     val isSingleton: Boolean,
     val dependencies: List<DependencyRef>,
     val injectableFields: List<InjectableFieldInfo> = emptyList(),
+    val aliases: MutableList<KSType> = mutableListOf(),
 )
 
 /**
@@ -91,6 +110,7 @@ data class InjectableClassInfo(
     val injectableFields: List<InjectableFieldInfo>,
     val isSingleton: Boolean,
     val qualifier: QualifierInfo?,
+    val aliases: List<KSType> = emptyList(),
 )
 
 /**


### PR DESCRIPTION
### Summary

Adds first class support for `@Binds` style aliases in Stitch, covering both class level and abstract module methods while preserving a single canonical implementation per binding.

### Implementation Details

- Introduce `@Binds` support in the compiler model:
  - `ModuleInfo` now carries both `provides` and `binds`.
  - `InjectableClassInfo` and `ProvidesInfo` have `aliases: List<KSType>`.
  - New `BindsInfo` model for abstract `@Binds` methods.

- Refine dependency graph construction:
  - Single `registerNode` helper registers a canonical implementation and any aliases under multiple `DependencyKey`s.
  - `@Inject` classes and `@Provides` methods can contribute aliases via `@Binds(aliases = [...])`.
  - Abstract `@Binds` methods bind an alias type to an existing implementation node.

- Update code generation:
  - Only canonical implementation types get singleton fields and lock objects.
  - Generate alias provider methods that delegate to the canonical provider.
  - Extend `GeneratedDependencyTable` routing so both canonical types and alias types resolve to the same node for both field injection and `Stitch.get<T>()`.

- Extend sample app to verify behavior:
  - `UserRepositoryImpl` implements `UserRepository` and `UserReader` with class level `@Binds` aliases and passes strict identity checks.
  - `ComplexService` implements `Processor` via a module `@Binds` method and shares the same singleton instance for both types.

Closes #35