### PR TITLE
refactor(di): Use '_initialized' flag for singleton caching & support nullable

### DIFF
--- a/app/src/main/java/com/harrytmthy/stitch/MainActivity.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/MainActivity.kt
@@ -43,6 +43,10 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var apiService: ApiService
 
+    @Named("null")
+    @Inject
+    var nullableInt: Int? = Int.MIN_VALUE // Should be replaced by null
+
     @Inject
     lateinit var viewModel: ViewModel
 
@@ -75,6 +79,7 @@ class MainActivity : AppCompatActivity() {
         check(complexService.cache === cacheService)
         check(Stitch.get<Processor>() === Stitch.get<ComplexService>())
         check(baseUrl === Stitch.get<String>(named("baseUrl")))
+        check(nullableInt == null)
 
         // Factory objects
         check(apiService !== Stitch.get<ApiService>())

--- a/app/src/main/java/com/harrytmthy/stitch/TestModule.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/TestModule.kt
@@ -113,6 +113,11 @@ object AppModule {
     @Provides
     fun provideBaseUrl(): String = "https://api.example.com/"
 
+    @Named("null")
+    @Singleton
+    @Provides
+    fun provideNullInt(): Int? = null
+
     @Module
     interface Inner {
 


### PR DESCRIPTION
### Summary

This PR refactors the singleton caching mechanism by adding a dedicated `_initialized` flag for every singleton binding.

### Implementation Details

- Introduced `_field_initialized` boolean flags to correctly track construction state.
- Updated double-checked locking logic to rely on the flag instead of the backing value.
- Fixed nullability in generated types by using `toTypeName()` consistently.
- Ensured correct behavior for nullable singletons such as `Int?` or custom nullable types.

Closes #37