### PR TITLE
refactor(component): Make singleton fast-paths respect scope & remove constructor params

### DIFF
--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
@@ -16,19 +16,12 @@
 
 package com.harrytmthy.stitch.api
 
-import com.harrytmthy.stitch.exception.MissingBindingException
 import com.harrytmthy.stitch.internal.Node
 import com.harrytmthy.stitch.internal.Registry
 
 object Stitch {
 
-    private val component by lazy {
-        Component(
-            nodeLookup = ::lookupNode,
-            singletons = Registry.singletons,
-            scoped = Registry.scoped,
-        )
-    }
+    private val component by lazy { Component() }
 
     fun register(vararg modules: Module) {
         modules.forEach { module ->
@@ -76,14 +69,6 @@ object Stitch {
     @PublishedApi
     internal fun <T : Any> getInternal(type: Class<T>, qualifier: Qualifier?, scope: Scope?): T =
         component.getInternal(type, qualifier, scope)
-
-    internal fun lookupNode(type: Class<*>, qualifier: Qualifier?, scopeRef: ScopeRef?): Node {
-        Registry.scopedDefinitions[scopeRef]?.get(type)?.get(qualifier)?.let { return it }
-        val inner = Registry.definitions[type] ?: throw MissingBindingException.missingType(type)
-        return inner.getOrElse(qualifier) {
-            throw MissingBindingException.missingQualifier(type, qualifier, inner.keys)
-        }
-    }
 }
 
 inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =

--- a/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/StitchTest.kt
+++ b/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/StitchTest.kt
@@ -664,6 +664,23 @@ class StitchTest {
     }
 
     @Test
+    fun `scope should return different instance of the same type (with singleton)`() {
+        val activityScope = scope("activity")
+        val homeModule = module {
+            singleton { Logger() }
+            scoped(activityScope) { Logger() }
+        }
+        Stitch.register(homeModule)
+        val activityScopeInstance = activityScope.newInstance().apply { open() }
+
+        val singletonLogger = Stitch.get<Logger>()
+        val scopedLogger = Stitch.get<Logger>(scope = activityScopeInstance)
+
+        assertSame(scopedLogger, activityScopeInstance.get())
+        assertNotSame(singletonLogger, scopedLogger)
+    }
+
+    @Test
     fun `inject lazy throws when closed and succeeds when open`() {
         val screenScope = scope("screen")
         val module = module {


### PR DESCRIPTION
### Summary

This PR refactors Component to remove design inconsistencies and fixes a scope-related bug in singleton resolution.

Closes #41