### PR TITLE
feat(di): Add Scope implementation

### DIFF
--- a/app/src/main/java/com/harrytmthy/stitch/ActivityComponentProvider.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/ActivityComponentProvider.kt
@@ -1,0 +1,7 @@
+package com.harrytmthy.stitch
+
+import com.harrytmthy.stitch.generated.StitchActivityScopeComponent
+
+interface ActivityComponentProvider {
+    val activityComponent: StitchActivityScopeComponent
+}

--- a/app/src/main/java/com/harrytmthy/stitch/CircleView.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/CircleView.kt
@@ -1,0 +1,37 @@
+package com.harrytmthy.stitch
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+import com.harrytmthy.stitch.annotations.Inject
+import com.harrytmthy.stitch.generated.StitchFragmentScopeComponent
+
+class CircleView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+
+    @Inject
+    lateinit var logger: Logger
+
+    fun inject(fragmentComponent: StitchFragmentScopeComponent) {
+        fragmentComponent.createViewWithFragmentScopeComponent().inject(this)
+        logger.log("something")
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        val radius = (minOf(width, height) / 2f) * 0.8f
+        val cx = width / 2f
+        val cy = height / 2f
+
+        paint.color = 0xFF008577.toInt()
+        canvas.drawCircle(cx, cy, radius, paint)
+    }
+}

--- a/app/src/main/java/com/harrytmthy/stitch/MainFragment.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/MainFragment.kt
@@ -1,0 +1,45 @@
+package com.harrytmthy.stitch
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.harrytmthy.stitch.annotations.Inject
+import com.harrytmthy.stitch.annotations.Named
+import com.harrytmthy.stitch.generated.StitchFragmentScopeComponent
+
+class MainFragment : Fragment() {
+
+    @Inject
+    lateinit var logger: Logger
+
+    @Named("activity")
+    @Inject
+    lateinit var activityCacheService: CacheService
+
+    @Named("fragment")
+    @Inject
+    lateinit var fragmentCacheService: CacheService
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_main, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val fragmentComponent = (requireActivity() as ActivityComponentProvider).activityComponent
+            .createFragmentScopeComponent()
+            .apply { inject(this@MainFragment) }
+        logger.log("something")
+        check(activityCacheService !== fragmentCacheService)
+        renderDotView(view.findViewById(R.id.view_circle), fragmentComponent)
+    }
+
+    private fun renderDotView(view: CircleView, fragmentComponent: StitchFragmentScopeComponent) {
+        view.inject(fragmentComponent)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!" />
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
-</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello World!" />
+
+    <com.harrytmthy.stitch.CircleView
+        android:id="@+id/view_circle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Scope.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Scope.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Meta-annotation that identifies a scope annotation for the DI path.
+ *
+ * Scope annotations are used to control the lifecycle and sharing of dependencies
+ * within a specific scope (e.g. Activity scope, Fragment scope). Each scope
+ * can depend on an upstream scope, forming a unidirectional dependency chain.
+ *
+ * Example usage:
+ * ```kotlin
+ * @Scope(dependsOn = Singleton::class)
+ * @Retention(AnnotationRetention.RUNTIME)
+ * annotation class ActivityScope
+ *
+ * @Scope(dependsOn = ActivityScope::class)
+ * @Retention(AnnotationRetention.RUNTIME)
+ * annotation class FragmentScope
+ * ```
+ *
+ * This creates a dependency chain: `@FragmentScope → @ActivityScope → @Singleton`
+ *
+ * **Dependency Flow Rules:**
+ * - Bindings in a scope can depend on bindings in the same scope or any ancestor scope
+ * - Bindings cannot depend on descendant scopes or sibling scopes
+ * - Example: `@FragmentScope` bindings can depend on `@ActivityScope` and `@Singleton` bindings
+ *
+ * **Generated Components:**
+ * - Each scope generates a `StitchXxxScopeComponent` class with double-checked locking
+ * - Root scopes (depend on Singleton) have no upstream property
+ * - Downstream scopes have an `upstream` property pointing to their dependency
+ * - Each component has a factory: `StitchXxxScopeComponentFactory.create()`
+ *
+ * **Field Injection:**
+ * - Classes can have fields from multiple scopes (must be on the same ancestor path)
+ * - Injector takes the deepest scope component as a parameter
+ * - Injection chains through upstream scopes automatically
+ *
+ * @param dependsOn The upstream scope that this scope depends on. Defaults to [Singleton]
+ *                  which marks this as a root custom scope. Use another scope annotation
+ *                  class to create downstream scopes.
+ *
+ * @see Singleton
+ * @see Named
+ * @see Qualifier
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Scope(
+    val dependsOn: KClass<*> = Singleton::class,
+)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/DependencyGraphBuilder.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/DependencyGraphBuilder.kt
@@ -27,16 +27,50 @@ import com.google.devtools.ksp.symbol.KSType
  */
 class DependencyGraphBuilder(private val logger: KSPLogger) {
 
-    fun buildGraph(scanResult: ScanResult): List<DependencyNode> {
+    /**
+     * Helper to find dependency using scope-aware resolution.
+     * Returns the node if found in current scope, ancestor scopes, or singleton/unscoped.
+     */
+    private fun findDependency(
+        type: KSType,
+        qualifier: QualifierInfo?,
+        currentScope: KSType?,
+        registry: Map<DependencyKey, DependencyNode>,
+        scopeGraph: ScopeGraph,
+    ): DependencyNode? {
+        // 1. Try exact match in current scope
+        val exactKey = DependencyKey(type, qualifier, currentScope)
+        registry[exactKey]?.let { return it }
+
+        // 2. Walk up the scope chain
+        if (currentScope != null) {
+            var ancestorScope: KSType? = scopeGraph.scopes[currentScope]?.dependsOn
+            while (ancestorScope != null) {
+                val ancestorKey = DependencyKey(type, qualifier, ancestorScope)
+                registry[ancestorKey]?.let { return it }
+                ancestorScope = scopeGraph.scopes[ancestorScope]?.dependsOn
+            }
+        }
+
+        // 3. Try singleton/unscoped (scope = null)
+        val singletonKey = DependencyKey(type, qualifier, null)
+        return registry[singletonKey]
+    }
+
+    fun buildGraph(scanResult: ScanResult, scopeGraph: ScopeGraph): List<DependencyNode> {
         val nodes = mutableListOf<DependencyNode>()
         val registry = mutableMapOf<DependencyKey, DependencyNode>()
 
+        // Track (type, qualifier) -> scope for uniqueness across all scopes
+        val typeQualifierRegistry = mutableMapOf<Pair<String, QualifierInfo?>, KSType?>()
+
         // Helper function to register a node under multiple keys (canonical + aliases)
         fun registerNode(node: DependencyNode, aliasTypes: List<KSType> = emptyList()) {
-            val allKeys = listOf(DependencyKey(node.type, node.qualifier)) +
-                aliasTypes.map { DependencyKey(it, node.qualifier) }
+            val allKeys = listOf(DependencyKey(node.type, node.qualifier, node.scopeAnnotation)) +
+                aliasTypes.map { DependencyKey(it, node.qualifier, node.scopeAnnotation) }
 
             for (key in allKeys) {
+                // Check for duplicate within same scope (existing behavior)
                 if (registry.containsKey(key)) {
                     val existing = registry[key]!!
                     val existingLocation = if (existing.providerFunction.isConstructor()) {
@@ -49,14 +83,41 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
                     } else {
                         "${node.providerModule.qualifiedName?.asString()}.${node.providerFunction.simpleName.asString()}()"
                     }
+                    val scopeName = key.scope?.declaration?.simpleName?.asString() ?: "Singleton"
                     logger.error(
                         "Duplicate binding for ${key.type.declaration.qualifiedName?.asString()} " +
-                            "with qualifier ${key.qualifier}.\n" +
+                            "with qualifier ${key.qualifier} in scope @$scopeName.\n" +
                             "Already provided by: $existingLocation\n" +
                             "Duplicate found in: $currentLocation",
                         node.providerFunction,
                     )
                 } else {
+                    // Check for duplicate across all scopes (Iteration 5)
+                    val typeName = key.type.declaration.qualifiedName?.asString()
+                    if (typeName != null) {
+                        val typeQualifierKey = typeName to key.qualifier
+                        if (typeQualifierRegistry.containsKey(typeQualifierKey)) {
+                            val existingScope = typeQualifierRegistry[typeQualifierKey]
+                            val existingScopeName = existingScope?.declaration?.simpleName?.asString() ?: "Singleton"
+                            val currentScopeName = key.scope?.declaration?.simpleName?.asString() ?: "Singleton"
+                            val currentLocation = if (node.providerFunction.isConstructor()) {
+                                "${node.providerModule.qualifiedName?.asString()} @Inject constructor"
+                            } else {
+                                "${node.providerModule.qualifiedName?.asString()}.${node.providerFunction.simpleName.asString()}()"
+                            }
+                            val qualifierStr = if (key.qualifier != null) " with qualifier ${key.qualifier}" else ""
+                            logger.error(
+                                "Binding for ${key.type.declaration.qualifiedName?.asString()}$qualifierStr " +
+                                    "already exists in @$existingScopeName scope.\n" +
+                                    "Cannot define another binding in @$currentScopeName scope.\n" +
+                                    "Each (type, qualifier) pair must have exactly one binding across all scopes.\n" +
+                                    "Duplicate found in: $currentLocation",
+                                node.providerFunction,
+                            )
+                        } else {
+                            typeQualifierRegistry[typeQualifierKey] = key.scope
+                        }
+                    }
                     registry[key] = node
                 }
             }
@@ -77,6 +138,7 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
                         DependencyRef(param.type, param.qualifier)
                     },
                     aliases = provider.aliases.toMutableList(),
+                    scopeAnnotation = provider.scopeAnnotation,
                 )
 
                 registerNode(node, provider.aliases)
@@ -103,6 +165,7 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
                 dependencies = allDependencies,
                 injectableFields = injectable.injectableFields,
                 aliases = injectable.aliases.toMutableList(),
+                scopeAnnotation = injectable.scopeAnnotation,
             )
 
             registerNode(node, injectable.aliases)
@@ -110,13 +173,18 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
 
         // Third pass: Process @Binds methods
         // @Binds methods reference an existing node and register it under an alias type
+        // Note: @Binds doesn't have its own scope - it inherits from the implementation node
         scanResult.modules.forEach { module ->
             module.binds.forEach { binds ->
-                val implKey = DependencyKey(binds.implementationType, binds.qualifier)
-                val existingNode = registry[implKey]
+                // Try to find existing node with any scope (need to search all entries)
+                val existingNode = registry.entries.firstOrNull { (key, _) ->
+                    key.type.declaration == binds.implementationType.declaration &&
+                        key.qualifier == binds.qualifier
+                }?.value
+
                 if (existingNode != null) {
-                    // Register the existing node under the alias type
-                    val aliasKey = DependencyKey(binds.aliasType, binds.qualifier)
+                    // Register the existing node under the alias type with same scope
+                    val aliasKey = DependencyKey(binds.aliasType, binds.qualifier, existingNode.scopeAnnotation)
                     if (registry.containsKey(aliasKey)) {
                         val conflicting = registry[aliasKey]!!
                         val conflictingLocation = if (conflicting.providerFunction.isConstructor()) {
@@ -125,9 +193,10 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
                             "${conflicting.providerModule.qualifiedName?.asString()}.${conflicting.providerFunction.simpleName.asString()}()"
                         }
                         val currentLocation = "${module.declaration.qualifiedName?.asString()}.${binds.declaration.simpleName.asString()}()"
+                        val scopeName = aliasKey.scope?.declaration?.simpleName?.asString() ?: "Singleton"
                         logger.error(
                             "Duplicate binding for ${aliasKey.type.declaration.qualifiedName?.asString()} " +
-                                "with qualifier ${aliasKey.qualifier}.\n" +
+                                "with qualifier ${aliasKey.qualifier} in scope @$scopeName.\n" +
                                 "Already provided by: $conflictingLocation\n" +
                                 "Duplicate found in: $currentLocation",
                             binds.declaration,
@@ -152,11 +221,11 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
             }
         }
 
-        // Fourth pass: Validate all dependencies exist
+        // Fourth pass: Validate all dependencies exist (scope-aware resolution)
         nodes.forEach { node ->
             node.dependencies.forEach { dep ->
-                val depKey = DependencyKey(dep.type, dep.qualifier)
-                if (!registry.containsKey(depKey)) {
+                val found = findDependency(dep.type, dep.qualifier, node.scopeAnnotation, registry, scopeGraph)
+                if (found == null) {
                     val requiredBy = if (node.providerFunction.isConstructor()) {
                         "${node.providerModule.qualifiedName?.asString()} @Inject constructor"
                     } else {
@@ -172,11 +241,16 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
             }
         }
 
-        // Fifth pass: Validate field injection dependencies
+        // Fifth pass: Validate field injection dependencies (scope-agnostic)
+        // For relaxed multi-component inject, we only check that binding exists ANYWHERE
         scanResult.fieldInjectors.forEach { injector ->
             injector.injectableFields.forEach { field ->
-                val depKey = DependencyKey(field.type, field.qualifier)
-                if (!registry.containsKey(depKey)) {
+                val hasBindingAnywhere = registry.keys.any { key ->
+                    key.type.declaration == field.type.declaration &&
+                        key.qualifier == field.qualifier
+                }
+
+                if (!hasBindingAnywhere) {
                     val className = injector.classDeclaration.qualifiedName?.asString()
                     logger.error(
                         "Missing binding for ${field.type.declaration.qualifiedName?.asString()} " +
@@ -189,24 +263,30 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
         }
 
         // Sixth pass: Detect cycles
-        detectCycles(nodes, registry)
+        detectCycles(nodes, registry, scopeGraph)
+
+        // Seventh pass: Validate scoped dependencies
+        validateScopedDependencies(nodes, registry, scopeGraph)
 
         return nodes
     }
 
-    private fun detectCycles(nodes: List<DependencyNode>, registry: Map<DependencyKey, DependencyNode>) {
+    private fun detectCycles(nodes: List<DependencyNode>, registry: Map<DependencyKey, DependencyNode>, scopeGraph: ScopeGraph) {
         val visiting = mutableSetOf<DependencyKey>()
         val visited = mutableSetOf<DependencyKey>()
 
         fun dfs(node: DependencyNode, path: List<DependencyNode>) {
-            val key = DependencyKey(node.type, node.qualifier)
+            val key = DependencyKey(node.type, node.qualifier, node.scopeAnnotation)
 
             if (visiting.contains(key)) {
                 // Cycle detected
-                val cyclePath = path.dropWhile { it.type != node.type || it.qualifier != node.qualifier } + node
+                val cyclePath = path.dropWhile {
+                    it.type != node.type || it.qualifier != node.qualifier || it.scopeAnnotation != node.scopeAnnotation
+                } + node
                 val cycleDescription = cyclePath.joinToString(" -> ") {
                     val qual = if (it.qualifier != null) " (${it.qualifier})" else ""
-                    "${it.type.declaration.qualifiedName?.asString()}$qual"
+                    val scope = if (it.scopeAnnotation != null) " @${it.scopeAnnotation.declaration.simpleName.asString()}" else ""
+                    "${it.type.declaration.qualifiedName?.asString()}$qual$scope"
                 }
                 logger.error(
                     "Dependency cycle detected: $cycleDescription",
@@ -222,8 +302,7 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
             visiting.add(key)
 
             node.dependencies.forEach { dep ->
-                val depKey = DependencyKey(dep.type, dep.qualifier)
-                registry[depKey]?.let { depNode ->
+                findDependency(dep.type, dep.qualifier, node.scopeAnnotation, registry, scopeGraph)?.let { depNode ->
                     dfs(depNode, path + node)
                 }
             }
@@ -233,26 +312,86 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
         }
 
         nodes.forEach { node ->
-            val key = DependencyKey(node.type, node.qualifier)
+            val key = DependencyKey(node.type, node.qualifier, node.scopeAnnotation)
             if (!visited.contains(key)) {
                 dfs(node, emptyList())
             }
         }
     }
 
+    /**
+     * Validates that scoped dependencies follow the correct dependency flow.
+     * Rule: A binding in scope S can only depend on same scope S or ancestor scopes.
+     */
+    private fun validateScopedDependencies(
+        nodes: List<DependencyNode>,
+        registry: Map<DependencyKey, DependencyNode>,
+        scopeGraph: ScopeGraph,
+    ) {
+        nodes.forEach { node ->
+            val nodeScope = node.scopeAnnotation ?: return@forEach // Unscoped/singleton, skip
+
+            val nodeScopeInfo = scopeGraph.scopes[nodeScope]
+            if (nodeScopeInfo == null) {
+                // Scope not found in graph - should not happen if scanner worked correctly
+                logger.error(
+                    "Scope ${nodeScope.declaration.simpleName.asString()} not found in scope graph",
+                    node.providerFunction,
+                )
+                return@forEach
+            }
+
+            node.dependencies.forEach { dep ->
+                val depNode = findDependency(dep.type, dep.qualifier, nodeScope, registry, scopeGraph) ?: return@forEach // Missing dep, already reported
+                val depScope = depNode.scopeAnnotation
+
+                if (depScope != null) {
+                    // Validate: dependency must be same scope or ancestor
+                    if (depScope != nodeScope && !isAncestor(depScope, nodeScope, scopeGraph)) {
+                        logger.error(
+                            "Scoped binding ${node.type.declaration.simpleName.asString()} " +
+                                "(${nodeScope.declaration.simpleName.asString()}) cannot depend on " +
+                                "${depNode.type.declaration.simpleName.asString()} " +
+                                "(${depScope.declaration.simpleName.asString()}). " +
+                                "Dependencies must flow upstream in the scope chain.",
+                            node.providerFunction,
+                        )
+                    }
+                }
+                // Singleton/unscoped dependencies are always OK (they're upstream of everything)
+            }
+        }
+    }
+
+    /**
+     * Checks if ancestor is an ancestor of descendant in the scope graph.
+     */
+    private fun isAncestor(ancestor: KSType, descendant: KSType, scopeGraph: ScopeGraph): Boolean {
+        var current = descendant
+        while (true) {
+            val upstream = scopeGraph.scopes[current]?.dependsOn ?: return false
+            if (upstream == ancestor) return true
+            current = upstream
+        }
+    }
+
     private data class DependencyKey(
         val type: KSType,
         val qualifier: QualifierInfo?,
+        val scope: KSType?, // null for singleton/unscoped
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is DependencyKey) return false
-            return type.declaration == other.type.declaration && qualifier == other.qualifier
+            return type.declaration == other.type.declaration &&
+                qualifier == other.qualifier &&
+                scope?.declaration == other.scope?.declaration
         }
 
         override fun hashCode(): Int {
             var result = type.declaration.hashCode()
             result = 31 * result + (qualifier?.hashCode() ?: 0)
+            result = 31 * result + (scope?.declaration?.hashCode() ?: 0)
             return result
         }
     }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -39,6 +39,7 @@ data class ProvidesInfo(
     val isSingleton: Boolean,
     val qualifier: QualifierInfo?,
     val aliases: List<KSType> = emptyList(),
+    val scopeAnnotation: KSType? = null,
 )
 
 /**
@@ -90,6 +91,7 @@ data class DependencyNode(
     val dependencies: List<DependencyRef>,
     val injectableFields: List<InjectableFieldInfo> = emptyList(),
     val aliases: MutableList<KSType> = mutableListOf(),
+    val scopeAnnotation: KSType? = null,
 )
 
 /**
@@ -111,6 +113,7 @@ data class InjectableClassInfo(
     val isSingleton: Boolean,
     val qualifier: QualifierInfo?,
     val aliases: List<KSType> = emptyList(),
+    val scopeAnnotation: KSType? = null,
 )
 
 /**
@@ -120,6 +123,7 @@ data class InjectableFieldInfo(
     val name: String,
     val type: KSType,
     val qualifier: QualifierInfo?,
+    val scopeAnnotation: KSType? = null,
 )
 
 /**
@@ -129,6 +133,33 @@ data class InjectableFieldInfo(
 data class FieldInjectorInfo(
     val classDeclaration: KSClassDeclaration,
     val injectableFields: List<InjectableFieldInfo>,
+    val scopeUsage: ClassScopeUsage = ClassScopeUsage(null, emptySet(), emptyList()),
+)
+
+/**
+ * Represents information about a scope annotation.
+ */
+data class ScopeInfo(
+    val annotation: KSType, // The scope annotation type (e.g. ActivityScope)
+    val dependsOn: KSType?, // Upstream scope (null if depends on Singleton)
+    val depth: Int, // Distance from Singleton (0 = root custom scope, 1+ = downstream)
+)
+
+/**
+ * Represents the complete scope dependency graph.
+ */
+data class ScopeGraph(
+    val scopes: Map<KSType, ScopeInfo>, // All discovered custom scopes
+    val rootScopes: Set<KSType>, // Scopes that depend directly on Singleton
+)
+
+/**
+ * Represents scope usage analysis for a class with field injection.
+ */
+data class ClassScopeUsage(
+    val deepestScope: KSType?, // Deepest scope used in fields (null if only Singleton/unscoped)
+    val usedScopes: Set<KSType>, // All custom scopes used in fields (excludes Singleton)
+    val ancestorPath: List<KSType>, // Ordered path from deepest to Singleton (excludes Singleton)
 )
 
 /**

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ScopeGraphBuilder.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ScopeGraphBuilder.kt
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueArgument
+import kotlin.reflect.KClass
+
+/**
+ * Builds the scope dependency graph from @Scope-annotated annotations.
+ *
+ * Responsibilities:
+ * 1. Discover all scope annotations (annotations annotated with @Scope)
+ * 2. Extract `dependsOn` parameter from each @Scope annotation
+ * 3. Build dependency graph and validate acyclicity
+ * 4. Calculate depth for each scope (distance from root)
+ * 5. Return structured ScopeGraph
+ */
+class ScopeGraphBuilder(private val logger: KSPLogger) {
+
+    fun buildScopeGraph(resolver: Resolver): ScopeGraph {
+        // Step 1: Discover all scope annotations
+        val scopeAnnotations = discoverScopeAnnotations(resolver)
+
+        if (scopeAnnotations.isEmpty()) {
+            logger.info("Stitch: No custom scopes found")
+            return ScopeGraph(emptyMap(), emptySet())
+        }
+
+        logger.info("Stitch: Discovered ${scopeAnnotations.size} custom scope annotation(s)")
+
+        // Step 2: Extract dependsOn for each scope
+        val scopeDependencies = mutableMapOf<KSType, KSType?>()
+        scopeAnnotations.forEach { scopeAnnotation ->
+            val dependsOn = extractDependsOn(scopeAnnotation, resolver)
+            scopeDependencies[scopeAnnotation] = dependsOn
+
+            val scopeName = scopeAnnotation.declaration.simpleName.asString()
+            val dependsOnName = dependsOn?.declaration?.simpleName?.asString() ?: "Singleton"
+            logger.info("Stitch: @$scopeName → @$dependsOnName")
+        }
+
+        // Step 3: Validate acyclic graph
+        validateAcyclic(scopeDependencies)
+
+        // Step 4: Calculate depth for each scope
+        val depths = calculateDepths(scopeDependencies)
+
+        // Step 5: Build ScopeInfo map
+        val scopeInfos = scopeDependencies.map { (scope, dependsOn) ->
+            scope to ScopeInfo(
+                annotation = scope,
+                dependsOn = dependsOn,
+                depth = depths[scope]!!,
+            )
+        }.toMap()
+
+        // Step 6: Identify root scopes (those that depend on Singleton)
+        val rootScopes = scopeInfos.filter { it.value.dependsOn == null }.keys
+
+        return ScopeGraph(scopeInfos, rootScopes)
+    }
+
+    /**
+     * Discovers all annotations that are themselves annotated with @Scope.
+     */
+    private fun discoverScopeAnnotations(resolver: Resolver): List<KSType> {
+        val scopeAnnotations = mutableListOf<KSType>()
+
+        // Find all symbols annotated with @Scope meta-annotation
+        listOf(STITCH_SCOPE, JAVAX_SCOPE).forEach { scopeMetaAnnotation ->
+            val annotated = resolver.getSymbolsWithAnnotation(scopeMetaAnnotation)
+
+            annotated.forEach { symbol ->
+                // The symbol itself is a scope annotation (e.g. @ActivityScope)
+                if (symbol is KSClassDeclaration) {
+                    val annotationType = symbol.asStarProjectedType()
+                    scopeAnnotations.add(annotationType)
+                }
+            }
+        }
+
+        return scopeAnnotations
+    }
+
+    /**
+     * Extracts the `dependsOn` parameter from a @Scope annotation.
+     * Returns null if depends on Singleton (default or explicit).
+     */
+    private fun extractDependsOn(scopeAnnotationType: KSType, resolver: Resolver): KSType? {
+        val scopeDeclaration = scopeAnnotationType.declaration
+
+        // Find the @Scope annotation on this annotation class
+        val scopeAnnotation = scopeDeclaration.annotations.firstOrNull { annotation ->
+            val annotationName = annotation.annotationType.resolve().declaration.qualifiedName?.asString()
+            annotationName == STITCH_SCOPE || annotationName == JAVAX_SCOPE
+        } ?: return null
+
+        // Extract the `dependsOn` parameter value
+        val dependsOnArg = scopeAnnotation.arguments.firstOrNull { it.name?.asString() == "dependsOn" }
+
+        if (dependsOnArg == null) {
+            // No explicit dependsOn parameter, defaults to Singleton
+            return null
+        }
+
+        // The value is a KClass reference
+        val dependsOnKClass = dependsOnArg.value as? KClass<*>
+
+        // Resolve the KClass to a KSType
+        val dependsOnType = resolveKClassToKSType(dependsOnArg, resolver)
+
+        // Check if it's Singleton (either Stitch or javax)
+        val isSingleton = isSingletonType(dependsOnType)
+
+        return if (isSingleton) null else dependsOnType
+    }
+
+    /**
+     * Resolves a KClass<*> argument to a KSType.
+     */
+    private fun resolveKClassToKSType(argument: KSValueArgument, resolver: Resolver): KSType {
+        // The value is stored as a KSType in KSP
+        return argument.value as KSType
+    }
+
+    /**
+     * Checks if a type is Singleton (Stitch or javax).
+     */
+    private fun isSingletonType(type: KSType?): Boolean {
+        if (type == null) return true
+        val qualifiedName = type.declaration.qualifiedName?.asString() ?: return false
+        return qualifiedName == STITCH_SINGLETON || qualifiedName == JAVAX_SINGLETON
+    }
+
+    /**
+     * Validates that the scope dependency graph is acyclic.
+     * Uses DFS-based cycle detection.
+     */
+    private fun validateAcyclic(scopeDependencies: Map<KSType, KSType?>) {
+        val visiting = mutableSetOf<KSType>()
+        val visited = mutableSetOf<KSType>()
+
+        fun dfs(scope: KSType, path: List<String>) {
+            if (scope in visiting) {
+                // Cycle detected
+                val cyclePath = path.joinToString(" → ")
+                logger.error(
+                    "Cycle detected in scope dependencies: $cyclePath → ${scope.declaration.simpleName.asString()}. " +
+                        "Scope dependency chains must be acyclic.",
+                    scope.declaration,
+                )
+                throw IllegalStateException("Cycle in scope graph")
+            }
+
+            if (scope in visited) return
+
+            visiting.add(scope)
+
+            val upstream = scopeDependencies[scope]
+            if (upstream != null) {
+                val newPath = path + scope.declaration.simpleName.asString()
+                dfs(upstream, newPath)
+            }
+
+            visiting.remove(scope)
+            visited.add(scope)
+        }
+
+        scopeDependencies.keys.forEach { scope ->
+            dfs(scope, emptyList())
+        }
+    }
+
+    /**
+     * Calculates the depth of each scope (distance from Singleton).
+     * Root scopes (depend on Singleton) have depth 0.
+     */
+    private fun calculateDepths(scopeDependencies: Map<KSType, KSType?>): Map<KSType, Int> {
+        val depths = mutableMapOf<KSType, Int>()
+
+        fun calculateDepth(scope: KSType): Int {
+            if (scope in depths) return depths[scope]!!
+
+            val upstream = scopeDependencies[scope]
+            val depth = if (upstream == null) {
+                // Root scope (depends on Singleton)
+                0
+            } else {
+                // Recursive: depth = parent depth + 1
+                calculateDepth(upstream) + 1
+            }
+
+            depths[scope] = depth
+            return depth
+        }
+
+        scopeDependencies.keys.forEach { calculateDepth(it) }
+        return depths
+    }
+
+    companion object {
+        private const val STITCH_SCOPE = "com.harrytmthy.stitch.annotations.Scope"
+        private const val JAVAX_SCOPE = "javax.inject.Scope"
+        private const val STITCH_SINGLETON = "com.harrytmthy.stitch.annotations.Singleton"
+        private const val JAVAX_SINGLETON = "javax.inject.Singleton"
+    }
+}

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -33,6 +33,7 @@ class StitchSymbolProcessor(
     private val logger: KSPLogger,
 ) : SymbolProcessor {
 
+    private val scopeGraphBuilder = ScopeGraphBuilder(logger)
     private val moduleScanner = ModuleScanner(logger)
     private val graphBuilder = DependencyGraphBuilder(logger)
     private val codeGen = StitchCodeGenerator(codeGenerator, logger)
@@ -46,8 +47,11 @@ class StitchSymbolProcessor(
 
         logger.info("Stitch: Starting dependency injection code generation")
 
+        // Build scope graph first
+        val scopeGraph = scopeGraphBuilder.buildScopeGraph(resolver)
+
         // Scan for @Module classes and @Inject constructors
-        val scanResult = moduleScanner.scanAll(resolver)
+        val scanResult = moduleScanner.scanAll(resolver, scopeGraph)
 
         if (scanResult.modules.isEmpty() && scanResult.injectables.isEmpty()) {
             logger.info("Stitch: No @Module or @Inject found, skipping code generation")
@@ -57,10 +61,10 @@ class StitchSymbolProcessor(
         logger.info("Stitch: Found ${scanResult.modules.size} module(s), ${scanResult.injectables.size} @Inject class(es), ${scanResult.fieldInjectors.size} field injection class(es)")
 
         // Build dependency graph and validate
-        val graph = graphBuilder.buildGraph(scanResult)
+        val graph = graphBuilder.buildGraph(scanResult, scopeGraph)
 
         // Generate DI component and injector objects
-        codeGen.generateComponentAndInjector(graph, scanResult.fieldInjectors)
+        codeGen.generateComponentAndInjector(graph, scanResult.fieldInjectors, scopeGraph)
 
         logger.info("Stitch: Code generation completed successfully")
 

--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -110,7 +110,12 @@ public final class com/harrytmthy/stitch/internal/DefinitionType : java/lang/Enu
 	public static fun values ()[Lcom/harrytmthy/stitch/internal/DefinitionType;
 }
 
-public abstract interface class com/harrytmthy/stitch/internal/StitchInjector {
-	public abstract fun inject (Ljava/lang/Object;)V
+public abstract class com/harrytmthy/stitch/internal/StitchComponent {
+	public fun <init> ()V
+	public final fun inject (Ljava/lang/Object;)V
+}
+
+public abstract interface class com/harrytmthy/stitch/internal/StitchScopedInjector {
+	public abstract fun inject (Ljava/lang/Object;Ljava/lang/Object;)V
 }
 

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/StitchComponent.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/StitchComponent.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.internal
+
+/**
+ * Base class for all generated Stitch components.
+ *
+ * Provides a default `inject(target: Any)` method that enables users to write
+ * `component.inject(this)` before compilation, avoiding unresolved reference errors.
+ * Once the project is compiled with `@Inject`-annotated fields, KSP generates typed
+ * `inject(target: SpecificType)` methods that take precedence due to Kotlin's
+ * overload resolution favoring more specific types.
+ *
+ * Example:
+ * ```kotlin
+ * class MainActivity : AppCompatActivity() {
+ *     private val activityComponent = StitchDiComponent.createActivityScopeComponent()
+ *
+ *     override fun onCreate(savedInstanceState: Bundle?) {
+ *         activityComponent.inject(this)  // Resolves to inject(Any) before compilation
+ *         super.onCreate(savedInstanceState)
+ *     }
+ * }
+ * ```
+ *
+ * After adding `@Inject` fields and recompiling:
+ * ```kotlin
+ * // Generated in StitchActivityScopeComponent
+ * override fun inject(target: MainActivity) {  // More specific, takes precedence
+ *     target.someField = someProvider()
+ *     StitchDiComponent.injectMainActivity(target)
+ * }
+ * ```
+ */
+abstract class StitchComponent {
+
+    /**
+     * No-op base inject method.
+     *
+     * This method does nothing and is intended to be shadowed by generated typed inject methods.
+     * It allows `component.inject(this)` to compile before KSP generates the actual function.
+     *
+     * @param target The object to inject dependencies into (ignored in base implementation)
+     */
+    fun inject(target: Any) {
+        // No-op: actual injection is performed by generated typed overloads
+    }
+}

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/StitchScopedInjector.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/StitchScopedInjector.kt
@@ -17,23 +17,30 @@
 package com.harrytmthy.stitch.internal
 
 /**
- * Type-safe injector interface for field injection.
+ * Type-safe scoped injector interface for field injection with custom scopes.
  *
  * This interface is implemented by generated injector objects for each class
- * that has field-level @Inject annotations, ensuring zero-overhead injection.
+ * that has scoped field-level @Inject annotations, ensuring zero-overhead injection
+ * with compile-time type safety for scope components.
  *
  * Example:
  * ```
- * StitchMainActivityInjector.inject(this)
+ * val activityComponent = StitchActivityScopeComponentFactory.create()
+ * StitchMainActivityInjector.inject(this, activityComponent)
  * ```
  *
  * **Note**: This is a public API implemented by generated code. Do not implement manually.
+ *
+ * @param T The type to inject fields into
+ * @param C The scope component type required for injection
  */
-interface StitchInjector<in T> {
+interface StitchScopedInjector<in T, in C> {
+
     /**
-     * Injects fields into the target instance.
+     * Injects fields into the target instance using the provided scope component.
      *
      * @param target The instance to inject fields into
+     * @param scopeComponent The scope component providing scoped dependencies
      */
-    fun inject(target: T)
+    fun inject(target: T, scopeComponent: C)
 }


### PR DESCRIPTION
### Summary

This PR introduces first-class scope support to Stitch’s DI pipeline and updates the Android sample to exercise a three-level scope chain (`ActivityScope → FragmentScope → ViewWithFragmentScope`). The compiler now understands custom scopes, validates cross-scope dependencies, and generates hierarchical components that resolve dependencies from their own scope, ancestor scopes, or singleton space. Field injection has been migrated to a relaxed multi-component model via `StitchComponent`, and the sample verifies correct scoping across Activity, Fragment, and View.

### Implementation Details

- **Scope model & scanning**
  - Added `@Scope(dependsOn = …)` support and introduced `ScopeInfo`, `ScopeGraph`, and `ClassScopeUsage` to model custom scopes and their relationships.
  - Introduced `ScopeGraphBuilder` and integrated it into `StitchSymbolProcessor` so the scope graph is built before scanning modules and injectables.
  - Extended `ModuleScanner` to:
    - Detect scope annotations on `@Inject` classes, `@Provides` methods, and `@Inject` fields via `getScopeAnnotation()` with the `STITCH_SCOPE` meta-annotation.
    - Store scope information in `ProvidesInfo`, `InjectableClassInfo`, `InjectableFieldInfo`, and `FieldInjectorInfo`.
    - Enforce that a binding cannot be both `@Singleton` and scoped (error if both are present).

- **Scope-aware dependency graph**
  - Updated `DependencyNode` and `DependencyKey` to carry an optional `scopeAnnotation`, making scope part of the identity for bindings.
  - Implemented `findDependency(type, qualifier, currentScope, registry, scopeGraph)` that:
    - Tries an exact match in the current scope.
    - Walks up the scope chain via `ScopeGraph` to search ancestor scopes.
    - Falls back to singleton/unscoped bindings when `scope = null`.
  - Introduced a cross-scope uniqueness check so each `(type, qualifier)` pair can only exist once across all scopes (with clear error messages that include the existing and conflicting scopes).
  - Adjusted graph validation:
    - Constructor dependencies now use scope-aware resolution and report missing bindings with the usual “required by” context.
    - Field injection validation is relaxed to “binding exists anywhere” to support multi-component inject while the actual component decides what it can see from its vantage point.
    - Cycle detection now includes scope in the diagnostic path (e.g. `Foo @ActivityScope -> Bar @FragmentScope`) and uses `findDependency` so cycles across scopes are detected correctly.
    - Added `validateScopedDependencies` to ensure that scoped bindings only depend on same-scope or ancestor scopes. Any downstream or “sideways” dependency is flagged as an error.

- **Scope-aware code generation**
  - Reworked `StitchCodeGenerator` to accept the full `ScopeGraph` and:
    - Split nodes into unscoped/singleton vs scoped groups.
    - Generate a single `StitchDiComponent` for singleton/unscoped bindings.
    - Generate one `Stitch<ScopeName>Component` per custom scope.
  - Each scope component:
    - Extends `StitchComponent`.
    - For non-root scopes, holds a single `upstream: Stitch<UpstreamScope>Component` reference set via the primary constructor.
    - Declares DCL fields and provider methods for its scoped bindings (using the same double-checked locking pattern as singletons).
    - Exposes `create<ChildScope>Component()` methods for any downstream scopes, wiring the `upstream` parameter correctly.
  - `StitchDiComponent`:
    - Continues to be the root object component for singleton/unscoped bindings.
    - Adds `create<ActivityScope>Component()`–style factory methods for all root custom scopes (scopes that depend directly on Singleton).
  - Provider bodies and injection:
    - Introduced `DependencyLocation` and `resolveDependency` to decide whether a dependency is in the same scope, an ancestor scope, or singleton space.
    - `addProviderCall` and the new `generateScopeFieldInjector` use `buildUpstreamChain(currentScope, targetScope, scopeGraph)` to emit correctly qualified calls (`method()`, `upstream.method()`, `upstream.upstream.method()`, or `StitchDiComponent.method()`), without requiring every scope to re-declare all upstream providers.
  - Field injection API:
    - Removed `StitchInjector` and `StitchScopedInjector` in favor of an abstract `StitchComponent` with a no-op `inject(target: Any)` base method.
    - Generated components now declare typed `inject(target: T)` overloads for all classes with `@Inject` fields.
    - `StitchDiComponent` injects only fields resolvable from singleton/unscoped space.
    - Each scope component injects any fields it can resolve from its own scope, its upstream chain, or `StitchDiComponent`, enabling relaxed multi-component injection (`activityComponent.inject(activity)`, `fragmentComponent.inject(fragment)`, `viewWithFragmentComponent.inject(view)`).

- **Android sample: Activity / Fragment / View scopes**
  - Defined three custom scopes in `TestModule.kt`:
    - `@ActivityScope(dependsOn = Singleton::class)`
    - `@FragmentScope(dependsOn = ActivityScope::class)`
    - `@ViewWithFragmentScope(dependsOn = FragmentScope::class)` (no bindings, used to prove downstream scope behavior).
  - Updated bindings:
    - Converted `CacheService` to a plain class and added:
      - `@Singleton @Provides fun provideSingletonCacheService(): CacheService`
      - `@ActivityScope @Named("activity") @Provides fun provideActivityScopedCacheService(): CacheService`
      - `@FragmentScope @Named("fragment") @Provides fun provideFragmentScopedCacheService(): CacheService`
    - Changed `ViewModel` to an `@ActivityScope` `@Inject` class with constructor-injected `UserRepository` and `@Named("activity") CacheService`, plus field-injected `Logger` to exercise mixed injection modes.
  - Wiring:
    - `MainActivity` now implements `ActivityComponentProvider` and exposes `activityComponent = StitchDiComponent.createActivityScopeComponent()`, then calls `activityComponent.inject(this)` in `onCreate`.
    - `MainFragment` obtains its component via `(requireActivity() as ActivityComponentProvider).activityComponent.createFragmentScopeComponent()` and calls `.inject(this)`, verifying that:
      - `logger` comes from singleton scope.
      - `activityCacheService` uses the Activity-scoped cache.
      - `fragmentCacheService` uses the Fragment-scoped cache, and they are distinct instances.
    - `CircleView` declares an `@Inject lateinit var logger: Logger` and an `inject(fragmentComponent: StitchFragmentScopeComponent)` method that calls `fragmentComponent.createViewWithFragmentScopeComponent().inject(this)` and logs a message. `@ViewWithFragmentScope` has no bindings, so this proves that a downstream scope with zero bindings can still be created and can inject singleton dependencies via the full scope chain.
  - Assertions in `MainActivity.assertStitch()` confirm the expected instance relationships across scopes, including:
    - `viewModel.cacheService === activityCacheService`
    - `activityCacheService === activityCacheService2`
    - `complexService.cache !== activityCacheService`

Closes #43