### PR TITLE
refactor(registry): Change Class<*> to KClass<*> for KMP support

### DIFF
--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -1,14 +1,14 @@
 public abstract interface class com/harrytmthy/stitch/api/Bindable {
-	public abstract fun bind (Ljava/lang/Class;)Lcom/harrytmthy/stitch/api/Bindable;
+	public abstract fun bind (Lkotlin/reflect/KClass;)Lcom/harrytmthy/stitch/api/Bindable;
 }
 
 public final class com/harrytmthy/stitch/api/Component {
-	public final fun getInternal (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
+	public final fun getInternal (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
 }
 
 public final class com/harrytmthy/stitch/api/Module {
 	public fun <init> (ZLkotlin/jvm/functions/Function1;)V
-	public final fun define-z0zhSdE (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
+	public final fun define-z0zhSdE (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
 }
 
 public final class com/harrytmthy/stitch/api/ModuleKt {
@@ -71,7 +71,7 @@ public final class com/harrytmthy/stitch/api/ScopeRef$Companion {
 
 public final class com/harrytmthy/stitch/api/Stitch {
 	public static final field INSTANCE Lcom/harrytmthy/stitch/api/Stitch;
-	public final fun getInternal (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
+	public final fun getInternal (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
 	public final fun register ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregister ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregisterAll ()V
@@ -91,8 +91,8 @@ public final class com/harrytmthy/stitch/exception/MissingBindingException : com
 }
 
 public final class com/harrytmthy/stitch/exception/MissingBindingException$Companion {
-	public final fun missingQualifier (Ljava/lang/Class;Lcom/harrytmthy/stitch/api/Qualifier;Ljava/util/Collection;)Lcom/harrytmthy/stitch/exception/MissingBindingException;
-	public final fun missingType (Ljava/lang/Class;)Lcom/harrytmthy/stitch/exception/MissingBindingException;
+	public final fun missingQualifier (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Ljava/util/Collection;)Lcom/harrytmthy/stitch/exception/MissingBindingException;
+	public final fun missingType (Lkotlin/reflect/KClass;)Lcom/harrytmthy/stitch/exception/MissingBindingException;
 }
 
 public final class com/harrytmthy/stitch/exception/MissingScopeException : com/harrytmthy/stitch/exception/GetFailedException {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Bindable.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Bindable.kt
@@ -16,8 +16,10 @@
 
 package com.harrytmthy.stitch.api
 
+import kotlin.reflect.KClass
+
 interface Bindable {
-    fun <T : Any> bind(type: Class<T>): Bindable
+    fun <T : Any> bind(type: KClass<T>): Bindable
 }
 
-inline fun <reified T : Any> Bindable.bind(): Bindable = bind(T::class.java)
+inline fun <reified T : Any> Bindable.bind(): Bindable = bind(T::class)

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
@@ -25,6 +25,7 @@ import com.harrytmthy.stitch.internal.Node
 import com.harrytmthy.stitch.internal.Registry
 import com.harrytmthy.stitch.internal.computeIfAbsentCompat
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
 
 class Component internal constructor() {
 
@@ -33,7 +34,7 @@ class Component internal constructor() {
     private val scopeContext = threadLocal { ScopeContext() }
 
     inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
-        getInternal(T::class.java, qualifier, scope)
+        getInternal(T::class, qualifier, scope)
 
     inline fun <reified T : Any> lazyOf(
         qualifier: Qualifier? = null,
@@ -44,7 +45,7 @@ class Component internal constructor() {
 
     @PublishedApi
     @Suppress("UNCHECKED_CAST")
-    internal fun <T : Any> getInternal(type: Class<T>, qualifier: Qualifier?, scope: Scope?): T {
+    internal fun <T : Any> getInternal(type: KClass<T>, qualifier: Qualifier?, scope: Scope?): T {
         val qualifierKey = qualifier ?: DefaultQualifier
         val scopeContext = scopeContext.get()
         val effectiveScope = scope ?: scopeContext.scope
@@ -129,7 +130,7 @@ class Component internal constructor() {
         scopeContext.remove()
     }
 
-    private fun lookupNode(type: Class<*>, qualifier: Qualifier?, scopeRef: ScopeRef?): Node {
+    private fun lookupNode(type: KClass<*>, qualifier: Qualifier?, scopeRef: ScopeRef?): Node {
         Registry.scopedDefinitions[scopeRef]?.get(type)?.get(qualifier)?.let { return it }
         val inner = Registry.definitions[type] ?: throw MissingBindingException.missingType(type)
         return inner.getOrElse(qualifier) {
@@ -142,7 +143,7 @@ class Component internal constructor() {
             override fun initialValue(): T = supplier()
         }
 
-    private fun Scope.ensureOpen(type: Class<*>, qualifier: Qualifier?) {
+    private fun Scope.ensureOpen(type: KClass<*>, qualifier: Qualifier?) {
         if (!isOpen()) {
             throw ScopeClosedException(type, qualifier, id)
         }

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
@@ -18,6 +18,7 @@ package com.harrytmthy.stitch.api
 
 import com.harrytmthy.stitch.internal.Node
 import com.harrytmthy.stitch.internal.Registry
+import kotlin.reflect.KClass
 
 object Stitch {
 
@@ -57,17 +58,17 @@ object Stitch {
     }
 
     inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
-        getInternal(T::class.java, qualifier, scope)
+        getInternal(T::class, qualifier, scope)
 
     inline fun <reified T : Any> inject(
         qualifier: Qualifier? = null,
         scope: Scope? = null,
     ): Lazy<T> {
-        return lazy(LazyThreadSafetyMode.NONE) { getInternal(T::class.java, qualifier, scope) }
+        return lazy(LazyThreadSafetyMode.NONE) { getInternal(T::class, qualifier, scope) }
     }
 
     @PublishedApi
-    internal fun <T : Any> getInternal(type: Class<T>, qualifier: Qualifier?, scope: Scope?): T =
+    internal fun <T : Any> getInternal(type: KClass<T>, qualifier: Qualifier?, scope: Scope?): T =
         component.getInternal(type, qualifier, scope)
 }
 

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/CycleException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/CycleException.kt
@@ -18,6 +18,7 @@ package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.api.Qualifier
 import com.harrytmthy.stitch.internal.Node
+import kotlin.reflect.KClass
 
 /**
  * Thrown when Stitch detects a dependency cycle during resolution.
@@ -36,7 +37,7 @@ import com.harrytmthy.stitch.internal.Node
  * moving one side to a factory that defers construction until first use.
  */
 class CycleException internal constructor(
-    type: Class<*>,
+    type: KClass<*>,
     qualifier: Qualifier?,
     path: List<Node>,
 ) : GetFailedException(

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/DuplicateBindingException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/DuplicateBindingException.kt
@@ -18,18 +18,19 @@ package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.api.Qualifier
 import com.harrytmthy.stitch.api.ScopeRef
+import kotlin.reflect.KClass
 
 /**
  * Thrown when duplicate bindings are detected for the same type and qualifier.
  */
 class DuplicateBindingException internal constructor(
-    type: Class<*>,
+    type: KClass<*>,
     qualifier: Qualifier?,
     scopeRef: ScopeRef?,
 ) : IllegalStateException(
     buildString {
         val qualStr = qualifier?.toString() ?: "<default>"
-        append("Duplicate binding for ${type.name} / $qualStr")
+        append("Duplicate binding for ${type.qualifiedName} / $qualStr")
         if (scopeRef != null) {
             append(" / '${scopeRef.name}'")
         }

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/GetFailedException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/GetFailedException.kt
@@ -17,6 +17,7 @@
 package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.api.Qualifier
+import kotlin.reflect.KClass
 
 /**
  * Base class for 'get path' errors thrown by Stitch.
@@ -25,9 +26,9 @@ import com.harrytmthy.stitch.api.Qualifier
  * This makes debugging easier and ensures crash reports more readable.
  */
 open class GetFailedException internal constructor(
-    type: Class<*>,
+    type: KClass<*>,
     qualifier: Qualifier?,
     explanation: String,
 ) : IllegalStateException(
-    "Failed to get ${type.name} (Qualifier: ${qualifier ?: "n/a"}): $explanation",
+    "Failed to get ${type.qualifiedName} (Qualifier: ${qualifier ?: "n/a"}): $explanation",
 )

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/MissingBindingException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/MissingBindingException.kt
@@ -17,6 +17,7 @@
 package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.api.Qualifier
+import kotlin.reflect.KClass
 
 /**
  * Thrown when a binding is missing for the requested type or qualifier.
@@ -26,7 +27,7 @@ import com.harrytmthy.stitch.api.Qualifier
  * - The requested qualifier does not exist for that type.
  */
 class MissingBindingException internal constructor(
-    type: Class<*>,
+    type: KClass<*>,
     qualifier: Qualifier?,
     explanation: String,
 ) : GetFailedException(type, qualifier, explanation) {
@@ -36,14 +37,14 @@ class MissingBindingException internal constructor(
         /**
          * Creates a MissingBindingException for a type that has no binding registered.
          */
-        fun missingType(type: Class<*>) =
+        fun missingType(type: KClass<*>) =
             MissingBindingException(type, null, "No binding for the requested type.")
 
         /**
          * Creates a MissingBindingException for a qualifier that doesn't exist for a type.
          */
         fun missingQualifier(
-            type: Class<*>,
+            type: KClass<*>,
             qualifier: Qualifier?,
             available: Collection<Qualifier?>,
         ): MissingBindingException {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/MissingScopeException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/MissingScopeException.kt
@@ -17,11 +17,12 @@
 package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.api.Qualifier
+import kotlin.reflect.KClass
 
 /**
  * Thrown when a scoped binding is requested without providing a scope.
  */
 class MissingScopeException internal constructor(
-    type: Class<*>,
+    type: KClass<*>,
     qualifier: Qualifier?,
 ) : GetFailedException(type, qualifier, "The requested type is scoped, but no scope provided.")

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/ScopeClosedException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/ScopeClosedException.kt
@@ -17,6 +17,7 @@
 package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.api.Qualifier
+import kotlin.reflect.KClass
 
 /**
  * Thrown when trying to resolve a scoped binding using a scope that is not open.
@@ -29,7 +30,7 @@ import com.harrytmthy.stitch.api.Qualifier
  * - Avoid holding on to references after `scope.close()`.
  */
 class ScopeClosedException internal constructor(
-    type: Class<*>,
+    type: KClass<*>,
     qualifier: Qualifier?,
     scopeId: Int,
 ) : GetFailedException(type, qualifier, explanation = "Scope with id '$scopeId' is not open!")

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
@@ -20,15 +20,16 @@ import com.harrytmthy.stitch.api.Bindable
 import com.harrytmthy.stitch.api.Component
 import com.harrytmthy.stitch.api.Qualifier
 import com.harrytmthy.stitch.api.ScopeRef
+import kotlin.reflect.KClass
 
 internal class Node(
-    val type: Class<*>,
+    val type: KClass<*>,
     val qualifier: Qualifier?,
     val scopeRef: ScopeRef?,
     val definitionType: DefinitionType,
     val factory: (Component) -> Any,
-    val onBind: (Class<*>, Node) -> Unit,
+    val onBind: (KClass<*>, Node) -> Unit,
 ) : Bindable {
 
-    override fun <T : Any> bind(type: Class<T>): Bindable = apply { onBind(type, this) }
+    override fun <T : Any> bind(type: KClass<T>): Bindable = apply { onBind(type, this) }
 }

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Registry.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Registry.kt
@@ -19,18 +19,18 @@ package com.harrytmthy.stitch.internal
 import com.harrytmthy.stitch.api.DefaultQualifier
 import com.harrytmthy.stitch.api.Qualifier
 import com.harrytmthy.stitch.api.ScopeRef
-import java.util.IdentityHashMap
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
 
 internal object Registry {
 
-    val definitions = IdentityHashMap<Class<*>, HashMap<Qualifier?, Node>>()
+    val definitions = HashMap<KClass<*>, HashMap<Qualifier?, Node>>()
 
-    val scopedDefinitions = HashMap<ScopeRef, IdentityHashMap<Class<*>, HashMap<Qualifier?, Node>>>()
+    val scopedDefinitions = HashMap<ScopeRef, HashMap<KClass<*>, HashMap<Qualifier?, Node>>>()
 
-    val singletons = ConcurrentHashMap<Class<*>, ConcurrentHashMap<Qualifier, Any>>()
+    val singletons = ConcurrentHashMap<KClass<*>, ConcurrentHashMap<Qualifier, Any>>()
 
-    val scoped = ConcurrentHashMap<Int, ConcurrentHashMap<Class<*>, ConcurrentHashMap<Qualifier, Any>>>()
+    val scoped = ConcurrentHashMap<Int, ConcurrentHashMap<KClass<*>, ConcurrentHashMap<Qualifier, Any>>>()
 
     fun remove(nodes: List<Node>) {
         for (node in nodes) {
@@ -87,7 +87,7 @@ internal object Registry {
         scoped.clear()
     }
 
-    private fun <Q, V> IdentityHashMap<Class<*>, HashMap<Q, V>>.removeFamily(type: Class<*>) {
+    private fun <Q, V> HashMap<KClass<*>, HashMap<Q, V>>.removeFamily(type: KClass<*>) {
         val family = this[type] ?: return
         val iterator = this.entries.iterator()
         while (iterator.hasNext()) {


### PR DESCRIPTION
### Summary

This PR migrates the Stitch SL path from `Class<*>` to `KClass<*>` as the canonical type key for both the public API and the internal registry. The goal is to make the SL path KMP-ready while preserving existing semantics and keeping performance within an acceptable range.

Closes #45