### PR TITLE
refactor(component): Replace ThreadLocal with ResolutionContext for KMP-safe resolution

### DIFF
--- a/build-logic/convention/src/main/kotlin/JvmConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmConventionPlugin.kt
@@ -36,6 +36,7 @@ class JvmConventionPlugin : Plugin<Project> {
             extensions.configure<KotlinJvmProjectExtension> {
                 compilerOptions.jvmTarget = JvmTarget.JVM_11
                 compilerOptions.allWarningsAsErrors = true
+                compilerOptions.freeCompilerArgs.add("-Xcontext-parameters")
             }
         }
     }

--- a/gradle/init.gradle.kts
+++ b/gradle/init.gradle.kts
@@ -1,4 +1,4 @@
-val ktlintVersion = "1.5.0"
+val ktlintVersion = "1.8.0"
 
 initscript {
     val spotlessVersion = "7.0.2"

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ModuleScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ModuleScanner.kt
@@ -115,6 +115,7 @@ class ModuleScanner(private val logger: KSPLogger) {
                             acc.injectConstructor = symbol
                         }
                     }
+
                     is KSPropertyDeclaration -> {
                         val classDeclaration = symbol.parentDeclaration as? KSClassDeclaration ?: return@forEach
                         accByClass.getOrPut(classDeclaration) {

--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -3,12 +3,12 @@ public abstract interface class com/harrytmthy/stitch/api/Bindable {
 }
 
 public final class com/harrytmthy/stitch/api/Component {
-	public final fun getInternal (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
+	public final fun getInternal (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;Lcom/harrytmthy/stitch/api/ResolutionContext;)Ljava/lang/Object;
 }
 
 public final class com/harrytmthy/stitch/api/Module {
 	public fun <init> (ZLkotlin/jvm/functions/Function1;)V
-	public final fun define-z0zhSdE (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
+	public final fun define-FENcUh4 (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
 }
 
 public final class com/harrytmthy/stitch/api/ModuleKt {
@@ -41,6 +41,11 @@ public final class com/harrytmthy/stitch/api/QualifierKt {
 	public static final fun named (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class com/harrytmthy/stitch/api/ResolutionContext {
+	public final fun getComponent ()Lcom/harrytmthy/stitch/api/Component;
+	public final fun getScope ()Lcom/harrytmthy/stitch/api/Scope;
+}
+
 public final class com/harrytmthy/stitch/api/Scope {
 	public final fun close ()V
 	public final fun open ()V
@@ -71,7 +76,7 @@ public final class com/harrytmthy/stitch/api/ScopeRef$Companion {
 
 public final class com/harrytmthy/stitch/api/Stitch {
 	public static final field INSTANCE Lcom/harrytmthy/stitch/api/Stitch;
-	public final fun getInternal (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;)Ljava/lang/Object;
+	public final fun getInternal (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;Lcom/harrytmthy/stitch/api/ResolutionContext;)Ljava/lang/Object;
 	public final fun register ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregister ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregisterAll ()V

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/ResolutionContext.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/ResolutionContext.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.api
+
+import com.harrytmthy.stitch.exception.CycleException
+import com.harrytmthy.stitch.internal.Node
+
+class ResolutionContext internal constructor(val component: Component, val scope: Scope?) {
+
+    private val stack = ArrayDeque<Node>()
+
+    private val indexByNode = HashMap<Node, Int>()
+
+    internal fun enter(node: Node) {
+        val nodeIndex = indexByNode[node]
+        if (nodeIndex != null) {
+            val cycle = ArrayList<Node>(stack.size - nodeIndex + 1)
+            for (index in nodeIndex until stack.size) {
+                cycle += stack[index]
+            }
+            cycle += node
+            throw CycleException(node.type, node.qualifier, cycle)
+        }
+        indexByNode[node] = stack.size
+        stack.addLast(node)
+    }
+
+    internal fun exit() {
+        val removed = stack.removeLast()
+        indexByNode.remove(removed)
+    }
+
+    inline fun <reified T : Any> get(qualifier: Qualifier? = null): T =
+        component.getInternal(T::class, qualifier, scope, resolutionContext = this)
+
+    inline fun <reified T : Any> lazyOf(qualifier: Qualifier? = null): Lazy<T> =
+        lazy(LazyThreadSafetyMode.NONE) {
+            component.getInternal(T::class, qualifier, scope, resolutionContext = this)
+        }
+}

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
@@ -36,7 +36,7 @@ object Stitch {
 
     private fun warmUp(nodes: List<Node>) {
         for (node in nodes) {
-            component.getInternal(node.type, node.qualifier, scope = null)
+            component.getInternal(node.type, node.qualifier, scope = null, resolutionContext = null)
         }
     }
 
@@ -54,22 +54,33 @@ object Stitch {
         Registry.clear()
         Named.clear()
         ScopeRef.clear()
-        component.clear()
     }
 
     inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
-        getInternal(T::class, qualifier, scope)
+        getInternal(T::class, qualifier, scope, resolutionContext = null)
+
+    context(resolutionContext: ResolutionContext)
+    inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =
+        getInternal(T::class, qualifier, scope, resolutionContext)
 
     inline fun <reified T : Any> inject(
         qualifier: Qualifier? = null,
         scope: Scope? = null,
     ): Lazy<T> {
-        return lazy(LazyThreadSafetyMode.NONE) { getInternal(T::class, qualifier, scope) }
+        return lazy(LazyThreadSafetyMode.NONE) {
+            getInternal(T::class, qualifier, scope, resolutionContext = null)
+        }
     }
 
     @PublishedApi
-    internal fun <T : Any> getInternal(type: KClass<T>, qualifier: Qualifier?, scope: Scope?): T =
-        component.getInternal(type, qualifier, scope)
+    internal fun <T : Any> getInternal(
+        type: KClass<T>,
+        qualifier: Qualifier?,
+        scope: Scope?,
+        resolutionContext: ResolutionContext?,
+    ): T {
+        return component.getInternal(type, qualifier, scope, resolutionContext)
+    }
 }
 
 inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
@@ -17,8 +17,8 @@
 package com.harrytmthy.stitch.internal
 
 import com.harrytmthy.stitch.api.Bindable
-import com.harrytmthy.stitch.api.Component
 import com.harrytmthy.stitch.api.Qualifier
+import com.harrytmthy.stitch.api.ResolutionContext
 import com.harrytmthy.stitch.api.ScopeRef
 import kotlin.reflect.KClass
 
@@ -27,7 +27,7 @@ internal class Node(
     val qualifier: Qualifier?,
     val scopeRef: ScopeRef?,
     val definitionType: DefinitionType,
-    val factory: (Component) -> Any,
+    val factory: (ResolutionContext) -> Any,
     val onBind: (KClass<*>, Node) -> Unit,
 ) : Bindable {
 

--- a/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/StitchTest.kt
+++ b/stitch/src/commonTest/kotlin/com/harrytmthy/stitch/StitchTest.kt
@@ -188,8 +188,8 @@ class StitchTest {
     @Test
     fun `get with detected cycle should throw CycleException`() {
         val module = module {
-            singleton { A(get()) } // A -> B
-            singleton { B(get()) } // B -> A
+            singleton { A(Stitch.get()) } // A -> B
+            singleton { B(Stitch.get()) } // B -> A
         }
         Stitch.register(module)
 
@@ -217,7 +217,7 @@ class StitchTest {
                 Bar()
             }
             singleton {
-                val barLazy: Lazy<Bar> = lazyOf(scope = null)
+                val barLazy: Lazy<Bar> = lazyOf()
                 singletonBuilds++
                 UsesLazyFactory(barLazy)
             }


### PR DESCRIPTION
### Summary

This PR removes all ThreadLocal usage from Stitch and replaces it with a multiplatform-ready `ResolutionContext` that carries component, scope, and cycle-tracking state through explicit propagation. This makes the dependency resolution engine portable across all KMP targets while preserving cycle detection, correct scoping semantics, and the existing ergonomics of `singleton { A(get()) }`.

### Implementation Details

- **Introduced `ResolutionContext`**
  - Holds the active `Component` and current `Scope?`
  - Maintains a portable cycle-tracking stack
  - Provides `get<T>()` and `lazyOf<T>()` helpers that reuse the same context

- **Updated dependency resolution**
  - `Component.getInternal` now receives an optional `ResolutionContext?`
  - A new context is created lazily when none is provided
  - The same context flows through all nested resolutions
  - Unified cycle detection across all platforms

- **Updated factory model**
  - All factories now use `ResolutionContext.() -> T`
  - Both scoped and unscoped bindings share a single `Node` factory model
  - Removed the previous Component-based factory calls

- **Removed all ThreadLocal-based logic**
  - Deleted `ResolutionStack` ThreadLocal
  - Deleted `ScopeContext`
  - Removed `clear()` logic tied to ThreadLocal state

- **Updated Node**
  - Consolidated scoped/unscoped factory model
  - Node now stores `factory: ResolutionContext.() -> Any`

- **Updated Stitch.get**
  - Added context-parameter version of `get`
  - Ensures `Stitch.get()` inside factories correctly uses the active `ResolutionContext`
  - Fully preserves cycle detection

- **All tests updated and passing**
  - Cycle detection tests confirm cross-context correctness
  - Scoped resolution tests confirm correct behavior without ScopeContext

This completes the transition to a pure `commonMain` dependency resolution model.

Closes #47