### PR TITLE
feat(di): Add BindingProvider and ModuleProvider

### DIFF
--- a/app/src/main/java/com/harrytmthy/stitch/TestModule.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/TestModule.kt
@@ -78,7 +78,7 @@ class ApiService @Inject constructor(
 }
 
 class CacheService {
-    fun get(key: String): String? {
+    fun get(key: String): String {
         return "cached_$key"
     }
 }


### PR DESCRIPTION
### Summary

This PR introduces two dedicated generated helpers for the DI graph:

- `ModuleProvider` as the single source of truth for class-based `@Module` instances.
- `BindingProvider` as the factory layer for all non-singleton bindings (scoped and unscoped).

`StitchDiComponent` and all `Stitch{Scope}Component`s now delegate non-singleton construction to `BindingProvider` and access class-based modules via `ModuleProvider`, while keeping singleton behaviour and scope resolution semantics intact.

### Implementation Details

- Added `generateModuleProvider(...)` to collect all class-based `@Module` types from `@Provides` bindings and emit a `ModuleProvider` object with one lazily shared instance per module (e.g. `ModuleProvider.appModule = AppModule()`).
- Removed the old `_Modules` nested holder from `StitchDiComponent` and updated `addProviderCall(...)` so that:
  - Object modules are still accessed as `ModuleObject.provideXxx(...)`.
  - Class modules are always accessed via `ModuleProvider.<moduleProp>.provideXxx(...)`.
- Introduced `generateBindingProvider(...)` and `generateBindingProviderFunction(...)` to emit a `BindingProvider` object:
  - One factory function per non-singleton binding, named using `generateDependencyName(...)`.
  - Each function takes all of its dependencies as parameters and performs construction via either:
    - `@Inject` constructor calls, plus optional field injection, or
    - `@Provides` module methods, using `ModuleProvider` for class modules and direct calls for object modules.
- Updated `generateProviderMethod(...)` so that:
  - Singleton bindings still use direct construction, with DCL and atomic caching when they are requested via field injection.
  - Non-singleton bindings are routed through a new `addBindingProviderCall(...)` helper that:
    - Resolves each dependency with `resolveDependency(...)`,
    - Builds the appropriate call chain (`StitchDiComponent`, same scope, `upstream`, or `upstream.upstream...`),
    - Calls the corresponding `BindingProvider` factory with named parameters.
- Ensured all usages of the old `generateMethodName(...)` now go through the new `generateDependencyName(...)` helper so that dependency names and BindingProvider method names stay aligned, including aliases and qualifiers.
- Adjusted scope component generation so that every scope component, including root scopes, receives an `upstream` constructor parameter and property, simplifying upstream traversal for both DI components and BindingProvider calls.

Closes #55