### PR TITLE
refactor(di): Improve StitchCodeGenerator correctness and performance

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ModuleScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ModuleScanner.kt
@@ -166,7 +166,7 @@ class ModuleScanner(private val logger: KSPLogger) {
             }
 
             // Single validation pass for all @Inject fields in this class.
-            val injectableFields = ArrayList<InjectableFieldInfo>()
+            val injectableFields = ArrayList<FieldInfo>()
             fields.forEach { property ->
                 val fieldName = property.simpleName.asString()
 
@@ -192,16 +192,21 @@ class ModuleScanner(private val logger: KSPLogger) {
                 val fieldType = property.type.resolve()
                 val qualifier = namedQualifierCache[property]
                 val scopeAnnotation = property.getScopeAnnotation()
-                injectableFields += InjectableFieldInfo(fieldName, fieldType, qualifier, scopeAnnotation)
+                injectableFields += FieldInfo(
+                    type = fieldType,
+                    qualifier = qualifier,
+                    name = fieldName,
+                    scopeAnnotation = scopeAnnotation,
+                )
             }
 
             // 1) Build InjectableClassInfo for constructor-injected classes (if any).
             if (ctor != null) {
                 val constructorParameters = ctor.parameters.map { param ->
-                    ParameterInfo(
-                        name = param.name?.asString() ?: "",
+                    FieldInfo(
                         type = param.type.resolve(),
                         qualifier = namedQualifierCache[param],
+                        name = param.name?.asString() ?: "",
                     )
                 }
 
@@ -301,10 +306,10 @@ class ModuleScanner(private val logger: KSPLogger) {
         val qualifier = namedQualifierCache[function]
 
         val parameters = function.parameters.map { param ->
-            ParameterInfo(
-                name = param.name?.asString() ?: "",
+            FieldInfo(
                 type = param.type.resolve(),
                 qualifier = namedQualifierCache[param],
+                name = param.name?.asString() ?: "",
             )
         }
 
@@ -422,7 +427,7 @@ class ModuleScanner(private val logger: KSPLogger) {
      * Each component will inject only fields it can resolve from its vantage point.
      */
     private fun analyzeClassScopeUsage(
-        injectableFields: List<InjectableFieldInfo>,
+        injectableFields: List<FieldInfo>,
         scopeGraph: ScopeGraph,
         classDeclaration: KSClassDeclaration,
     ): ClassScopeUsage {

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -61,10 +61,15 @@ class StitchSymbolProcessor(
         logger.info("Stitch: Found ${scanResult.modules.size} module(s), ${scanResult.injectables.size} @Inject class(es), ${scanResult.fieldInjectors.size} field injection class(es)")
 
         // Build dependency graph and validate
-        val graph = graphBuilder.buildGraph(scanResult, scopeGraph)
+        val dependencyGraph = graphBuilder.buildGraph(scanResult, scopeGraph)
 
         // Generate DI component and injector objects
-        codeGen.generateComponentAndInjector(graph, scanResult.fieldInjectors, scopeGraph)
+        codeGen.generateComponentAndInjector(
+            dependencyGraph.nodes,
+            dependencyGraph.registry,
+            scanResult.fieldInjectors,
+            scopeGraph,
+        )
 
         logger.info("Stitch: Code generation completed successfully")
 


### PR DESCRIPTION
### Summary

Improve StitchCodeGenerator correctness and performance by introducing a shared dependency registry with alias-aware lookup, unifying field/parameter models, and hardening unresolved dependency handling.

### Implementation Details

- Added a `BindingKey` model (type, qualifier, scope) and a `DependencyGraph` result that exposes both `nodes` and a `registry: Map<BindingKey, DependencyNode>`.
- Updated `DependencyGraphBuilder` to register each binding under both its canonical type and all alias types using `BindingKey`, and to return `DependencyGraph` instead of a raw node list.
- Changed `StitchSymbolProcessor` to pass `dependencyGraph.nodes` and `dependencyGraph.registry` into `StitchCodeGenerator.generateComponentAndInjector`.
- Refactored `StitchCodeGenerator` to:
  - Store `dependencyRegistry` and `scopeGraph` as fields and implement `resolveDependency` using O(1) lookups, walking current scope → upstream scopes → singleton/unscoped.
  - Make `requestedDepsByScope` alias-aware by indexing both canonical types and aliases into a node map keyed by `BindingKey(type, qualifier)`.
  - Replace the old `DependencyKey` with `BindingKey` for requested-deps tracking.
  - Route all resolution sites (`addProviderCall`, `addBindingProviderCall`, field injectors) through the new `resolveDependency`.
  - Introduce `reportUnresolvedDependency` to emit a clear KSP error if a dependency cannot be resolved at codegen time.
- Unified the parameter/field/dependency models by replacing `ParameterInfo`, `DependencyRef`, and `InjectableFieldInfo` with a single `FieldInfo` type used across `ModuleScanner`, `DependencyGraphBuilder`, and `StitchCodeGenerator`.

Closes #57