### PR TITLE
refactor(di): Improve DependencyGraphBuilder correctness and performance

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ModuleScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ModuleScanner.kt
@@ -328,7 +328,14 @@ class ModuleScanner(private val logger: KSPLogger) {
     }
 
     private fun scanBinds(function: KSFunctionDeclaration): BindsInfo? {
-        val functionName = function.simpleName.asString()
+        val functionName = function.qualifiedName?.asString()
+            ?: run {
+                logger.error(
+                    message = "@Binds method ${function.simpleName.asString()} must not be local",
+                    symbol = function,
+                )
+                return null
+            }
 
         // Validate: @Binds methods must be abstract
         if (!function.isAbstract) {


### PR DESCRIPTION
### Summary

This PR refactors DependencyGraphBuilder to improve correctness, eliminate NPE paths, and significantly reduce redundant lookups during graph construction and validation.

Closes #59