### PR TITLE
refactor(di): Centralize scope graph validation to ScopeGraphBuilder + improve its perf & correctness

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -16,6 +16,7 @@
 
 package com.harrytmthy.stitch.compiler
 
+import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
@@ -55,7 +56,6 @@ data class BindsInfo(
     val declaration: KSFunctionDeclaration,
     val implementationType: KSType,
     val aliasType: KSType,
-    val isSingleton: Boolean,
     val qualifier: QualifierInfo?,
 )
 
@@ -188,33 +188,15 @@ data class InjectableClassInfo(
 data class FieldInjectorInfo(
     val classDeclaration: KSClassDeclaration,
     val injectableFields: List<FieldInfo>,
-    val scopeUsage: ClassScopeUsage = ClassScopeUsage(null, emptySet(), emptyList()),
-)
-
-/**
- * Represents information about a scope annotation.
- */
-data class ScopeInfo(
-    val annotation: KSType, // The scope annotation type (e.g. ActivityScope)
-    val dependsOn: KSType?, // Upstream scope (null if depends on Singleton)
-    val depth: Int, // Distance from Singleton (0 = root custom scope, 1+ = downstream)
 )
 
 /**
  * Represents the complete scope dependency graph.
  */
 data class ScopeGraph(
-    val scopes: Map<KSType, ScopeInfo>, // All discovered custom scopes
-    val rootScopes: Set<KSType>, // Scopes that depend directly on Singleton
-)
-
-/**
- * Represents scope usage analysis for a class with field injection.
- */
-data class ClassScopeUsage(
-    val deepestScope: KSType?, // Deepest scope used in fields (null if only Singleton/unscoped)
-    val usedScopes: Set<KSType>, // All custom scopes used in fields (excludes Singleton)
-    val ancestorPath: List<KSType>, // Ordered path from deepest to Singleton (excludes Singleton)
+    val scopeDependencies: Map<KSType, KSType?>,
+    val scopeBySymbol: Map<KSAnnotated, KSType>,
+    val singletonAnnotatedSymbols: Set<KSAnnotated>,
 )
 
 /**

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -33,9 +33,6 @@ class StitchSymbolProcessor(
     private val logger: KSPLogger,
 ) : SymbolProcessor {
 
-    private val scopeGraphBuilder = ScopeGraphBuilder(logger)
-    private val moduleScanner = ModuleScanner(logger)
-    private val graphBuilder = DependencyGraphBuilder(logger)
     private val codeGen = StitchCodeGenerator(codeGenerator, logger)
 
     private var processed = false
@@ -48,10 +45,10 @@ class StitchSymbolProcessor(
         logger.info("Stitch: Starting dependency injection code generation")
 
         // Build scope graph first
-        val scopeGraph = scopeGraphBuilder.buildScopeGraph(resolver)
+        val scopeGraph = ScopeGraphBuilder(logger).buildScopeGraph(resolver)
 
         // Scan for @Module classes and @Inject constructors
-        val scanResult = moduleScanner.scanAll(resolver, scopeGraph)
+        val scanResult = ModuleScanner(logger, scopeGraph).scanAll(resolver)
 
         if (scanResult.modules.isEmpty() && scanResult.injectables.isEmpty()) {
             logger.info("Stitch: No @Module or @Inject found, skipping code generation")
@@ -61,7 +58,7 @@ class StitchSymbolProcessor(
         logger.info("Stitch: Found ${scanResult.modules.size} module(s), ${scanResult.injectables.size} @Inject class(es), ${scanResult.fieldInjectors.size} field injection class(es)")
 
         // Build dependency graph and validate
-        val dependencyGraph = graphBuilder.buildGraph(scanResult, scopeGraph)
+        val dependencyGraph = DependencyGraphBuilder(logger).buildGraph(scanResult, scopeGraph)
 
         // Generate DI component and injector objects
         codeGen.generateComponentAndInjector(


### PR DESCRIPTION
### Summary

Centralize scope discovery and validation in `ScopeGraphBuilder`, and refactor the compiler pipeline to consume a simpler `ScopeGraph` API, improving both correctness and performance of scope handling.

### Implementation Details

- Reworked `ScopeGraph` to expose:
  - `scopeDependencies: Map<KSType, KSType?>` as the scope DAG.
  - `scopeBySymbol: Map<KSAnnotated, KSType>` for symbol → scope lookup.
  - `singletonAnnotatedSymbols: Set<KSAnnotated>` for all singleton-annotated symbols.
- Updated `ScopeGraphBuilder` to:
  - Discover custom scopes by scanning meta-annotations (`@Scope` / `javax.inject.Scope`).
  - Extract `dependsOn` into `scopeDependencies`.
  - Validate acyclicity of the scope graph.
  - Build `scopeBySymbol` by scanning all symbols annotated with each custom scope.
  - Detect and report:
    - Symbols annotated with both `@Singleton` and a custom scope.
    - Symbols annotated with multiple custom scopes.
- Refactored `ModuleScanner` to:
  - Receive `ScopeGraph` via constructor and reuse `scopeBySymbol` / `singletonAnnotatedSymbols` for all scope/singleton lookups.
  - Remove local `getScopeAnnotation`, singleton detection, and unused `ClassScopeUsage` helpers.
  - Simplify models (`BindsInfo` no longer carries an unused `isSingleton` flag, `FieldInjectorInfo` drops scope usage).
- Adjusted `DependencyGraphBuilder` and `StitchCodeGenerator` to:
  - Replace all usages of `ScopeInfo` / `ScopeGraph.scopes` and depth/root scope logic with `scopeDependencies`.
  - Traverse upstream/child scopes using `scopeDependencies` only, keeping behavior intact while reducing indirection.

Closes #61