### PR TITLE
refactor(di): Improve scope resolution & ModuleScanner performance

### DIFF
--- a/app/src/main/java/com/harrytmthy/stitch/MainActivity.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/MainActivity.kt
@@ -40,11 +40,11 @@ class MainActivity : AppCompatActivity(), ActivityComponentProvider {
 
     @Inject
     @Named("activity")
-    lateinit var activityCacheService: CacheService
+    lateinit var activityCacheService: CacheServiceImpl
 
     @Inject
     @Named("activity")
-    lateinit var activityCacheService2: CacheService
+    lateinit var activityCacheService2: CacheServiceImpl
 
     @javax.inject.Inject
     lateinit var complexService: ComplexService

--- a/app/src/main/java/com/harrytmthy/stitch/MainFragment.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/MainFragment.kt
@@ -16,11 +16,11 @@ class MainFragment : Fragment() {
 
     @Named("activity")
     @Inject
-    lateinit var activityCacheService: CacheService
+    lateinit var activityCacheService: CacheServiceImpl
 
     @Named("fragment")
     @Inject
-    lateinit var fragmentCacheService: CacheService
+    lateinit var fragmentCacheService: CacheServiceImpl
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/harrytmthy/stitch/TestModule.kt
+++ b/app/src/main/java/com/harrytmthy/stitch/TestModule.kt
@@ -77,7 +77,9 @@ class ApiService @Inject constructor(
     }
 }
 
-class CacheService {
+interface CacheService
+
+class CacheServiceImpl : CacheService {
     fun get(key: String): String {
         return "cached_$key"
     }
@@ -86,7 +88,7 @@ class CacheService {
 @ActivityScope
 class ViewModel @Inject constructor(
     internal val repository: UserRepository,
-    @param:Named("activity") internal val cacheService: CacheService,
+    @param:Named("activity") internal val cacheService: CacheServiceImpl,
 ) {
 
     @Inject
@@ -103,7 +105,7 @@ class ComplexService @Inject constructor(
     private val logger: Logger
 ) : Processor {
     @Inject
-    lateinit var cache: CacheService
+    lateinit var cache: CacheServiceImpl
 
     @Inject
     @Named("baseUrl")
@@ -131,18 +133,19 @@ object AppModule {
     fun provideNullInt(): Int? = null
 
     @Singleton
+    @Binds(aliases = [CacheService::class])
     @Provides
-    fun provideSingletonCacheService(): CacheService = CacheService()
+    fun provideSingletonCacheService(): CacheServiceImpl = CacheServiceImpl()
 
     @ActivityScope
     @Named("activity")
     @Provides
-    fun provideActivityScopedCacheService(): CacheService = CacheService()
+    fun provideActivityScopedCacheService(): CacheServiceImpl = CacheServiceImpl()
 
     @FragmentScope
     @Named("fragment")
     @Provides
-    fun provideFragmentScopedCacheService(): CacheService = CacheService()
+    fun provideFragmentScopedCacheService(): CacheServiceImpl = CacheServiceImpl()
 
     @Module
     interface Inner {


### PR DESCRIPTION
### Summary

This PR simplifies scope resolution to exclusively use Stitch's `@Scope`, improves ModuleScanner performance, and adds support for combined `@Provides + @Binds(aliases=[...])`.

### Implementation Details

- Remove `javax.inject.Scope` support and restrict the scope graph to Stitch `@Scope`.
- Simplify `extractDependsOn()` to a single linear expression without fallback paths.
- Build `scopeDependencies`, `scopeBySymbol`, and `singletonAnnotatedSymbols` entirely in ScopeGraphBuilder.
- Refactor ModuleScanner into a single pass:
  - Iterate once over `moduleClass.getAllFunctions()`.
  - Route via a `when` block to `scanProvider()` or `scanBinds()`.
  - Allow `@Provides + @Binds(aliases=[...])` combinations.
- Remove obsolete fallback logic in `hasAnnotation()` and switch to strict FQN matching.

Closes #63