### PR TITLE
feat(di): Add StitchLogger & StitchProcessingException to enable fail-fast

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/DependencyGraphBuilder.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/DependencyGraphBuilder.kt
@@ -290,11 +290,10 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
                     val scope = if (it.scopeAnnotation != null) " @${it.scopeAnnotation.declaration.simpleName.asString()}" else ""
                     "${it.type.declaration.qualifiedName?.asString()}$qual$scope"
                 }
-                logger.error(
+                throw StitchProcessingException(
                     "Dependency cycle detected: $cycleDescription",
                     node.providerFunction,
                 )
-                return
             }
 
             if (visited.contains(node)) {

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchLogger.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchLogger.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSNode
+
+class StitchLogger(private val delegate: KSPLogger) : KSPLogger {
+
+    var hasError: Boolean = false
+        private set
+
+    override fun logging(message: String, symbol: KSNode?) {
+        delegate.logging(message, symbol)
+    }
+
+    override fun info(message: String, symbol: KSNode?) {
+        delegate.info(message, symbol)
+    }
+
+    override fun warn(message: String, symbol: KSNode?) {
+        delegate.warn(message, symbol)
+    }
+
+    override fun error(message: String, symbol: KSNode?) {
+        hasError = true
+        delegate.error(message, symbol)
+    }
+
+    override fun exception(e: Throwable) {
+        hasError = true
+        delegate.exception(e)
+    }
+}

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchProcessingException.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchProcessingException.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+import com.google.devtools.ksp.symbol.KSNode
+
+internal open class StitchProcessingException(
+    override val message: String? = null,
+    val symbol: KSNode? = null,
+) : IllegalStateException(message)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessorProvider.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessorProvider.kt
@@ -31,7 +31,7 @@ class StitchSymbolProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
         return StitchSymbolProcessor(
             codeGenerator = environment.codeGenerator,
-            logger = environment.logger,
+            logger = StitchLogger(delegate = environment.logger),
         )
     }
 }


### PR DESCRIPTION
### Summary

Introduce fail-fast behavior in the Stitch KSP processor by adding `StitchLogger` and `StitchProcessingException`, converting structural violations into hard failures, and centralizing phase-by-phase error gating.

### Implementation Details

Replace cycle and multi-scope errors with `StitchProcessingException`. Wrap the environment logger inside `StitchLogger` to track soft errors, then abort processing between phases using `ensureNoError()`. Update `StitchSymbolProcessor` to catch and surface hard failures cleanly.

Closes #65