### PR TITLE
refactor(di): Simplify StitchCodeGenerator dependency handling

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/DependencyGraphBuilder.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/DependencyGraphBuilder.kt
@@ -132,9 +132,7 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
                     type = provider.returnType,
                     qualifier = provider.qualifier,
                     isSingleton = provider.isSingleton,
-                    dependencies = provider.parameters.map { param ->
-                        FieldInfo(type = param.type, qualifier = param.qualifier)
-                    },
+                    constructorParameters = provider.parameters,
                     aliases = provider.aliases.toMutableList(),
                     scopeAnnotation = provider.scopeAnnotation,
                 )
@@ -144,22 +142,13 @@ class DependencyGraphBuilder(private val logger: KSPLogger) {
         }
 
         scanResult.injectables.forEach { injectable ->
-            val returnType = injectable.classDeclaration.asStarProjectedType()
-
-            // Dependencies include both constructor params AND injectable fields
-            val allDependencies = injectable.constructorParameters.map { param ->
-                FieldInfo(type = param.type, qualifier = param.qualifier)
-            } + injectable.injectableFields.map { field ->
-                FieldInfo(type = field.type, qualifier = field.qualifier)
-            }
-
             val node = DependencyNode(
                 providerModule = injectable.classDeclaration,
                 providerFunction = injectable.constructor,
-                type = returnType,
+                type = injectable.classDeclaration.asStarProjectedType(),
                 qualifier = injectable.qualifier,
                 isSingleton = injectable.isSingleton,
-                dependencies = allDependencies,
+                constructorParameters = injectable.constructorParameters,
                 injectableFields = injectable.injectableFields,
                 aliases = injectable.aliases.toMutableList(),
                 scopeAnnotation = injectable.scopeAnnotation,

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -161,11 +161,13 @@ data class DependencyNode(
     val type: KSType,
     val qualifier: QualifierInfo?,
     val isSingleton: Boolean,
-    val dependencies: List<FieldInfo>,
+    val constructorParameters: List<FieldInfo>,
     val injectableFields: List<FieldInfo> = emptyList(),
     val aliases: MutableList<KSType> = mutableListOf(),
     val scopeAnnotation: KSType? = null,
-)
+) {
+    val dependencies = constructorParameters + injectableFields
+}
 
 /**
  * Represents a class with @Inject constructor (and optional @Inject fields).


### PR DESCRIPTION
### Summary

Refactor the DI path to make `DependencyNode` model constructor vs field dependencies explicitly and simplify dependency resolution and provider generation inside `StitchCodeGenerator`.

Closes #69