### PR TITLE
chore: Bump AGP + Kotlin + KSP versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.11.2"
+androidGradlePlugin = "8.13.1"
 androidxAppcompat = "1.7.1"
 androidxBenchmark = "1.4.1"
 androidxCoreKtx = "1.17.0"
@@ -9,11 +9,11 @@ dagger = "2.54"
 dokka = "2.0.0"
 javaxInject = "1"
 koin = "4.1.1"
-kotlin = "2.2.20"
+kotlin = "2.2.21"
 kotlinBinaryCompatibility = "0.18.1"
-kotlinpoet = "2.0.0"
+kotlinpoet = "2.2.0"
 kotlinAtomicfu = "0.29.0"
-ksp = "2.2.20-2.0.4"
+ksp = "2.2.21-2.0.4"
 mavenPublishPlugin = "0.32.0"
 
 [libraries]


### PR DESCRIPTION
### Summary

Updates AGP, Kotlin, KotlinPoet, and KSP versions inside `libs.versions.toml` to their latest stable values.

Closes #71