### PR TITLE
refactor(compiler): Migrate DI scanner to string-based registry model

### DIFF
--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/StitchRoot.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/StitchRoot.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.annotations
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class StitchRoot

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/BindingPool.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/BindingPool.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+/**
+ * A map of bindings where both key & value point to the same instance (`key == value`).
+ *
+ * The purpose is to allow [Binding] and its subclasses to find the previously stored
+ * instance, for example:
+ *
+ * ```
+ * val binding = ProvidedBinding(type, qualifier, ...)
+ * bindingPool.add(binding)
+ *
+ * // True, if requestedBinding has the same type + qualifier
+ * check(binding == bindingPool[requestedBinding])
+ *
+ * // Also true
+ * check(binding == bindingPool[Binding(type, qualifier)])
+ * ```
+ *
+ * This allows passing [RequestedBinding] to get [ProvidedBinding] without any overhead from
+ * creating a new [Binding] instance (`Binding(type, qualifier)`).
+ */
+class BindingPool<E : Binding>(
+    initialCapacity: Int = 16,
+    loadFactor: Float = 0.75f,
+) : HashMap<Binding, E>(initialCapacity, loadFactor) {
+
+    fun add(element: E) {
+        this[element] = element
+    }
+}

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+/**
+ * Represents a binding.
+ */
+open class Binding(val type: String, val qualifier: Qualifier?) {
+
+    override fun hashCode(): Int =
+        if (qualifier != null) {
+            type.hashCode() + (31 * qualifier.hashCode())
+        } else {
+            type.hashCode()
+        }
+
+    override fun equals(other: Any?): Boolean =
+        other is Binding && other.type == this.type && other.qualifier == this.qualifier
+}
+
+/**
+ * Represents a provided binding that has been finalized by the aggregator module.
+ */
+class ProvidedBinding(
+    type: String,
+    qualifier: Qualifier?,
+    val scope: Scope?,
+    val location: String, // File path + line number
+) : Binding(type, qualifier) {
+
+    var dependencies: HashSet<Binding>? = null
+}
+
+/**
+ * Represents a requested binding via `@Inject`-annotated field. If there are requested bindings
+ * that are never provided, Stitch will apply an action based on the current module type:
+ * - Contributor: Put them as params of `@Contribute` which will be collected by the aggregator.
+ * - Aggregator: After collecting all contributions, they are considered as missing bindings.
+ */
+class RequestedBinding(
+    type: String,
+    qualifier: Qualifier?,
+    val fieldName: String,
+) : Binding(type, qualifier)
+
+sealed class Qualifier {
+    data class Named(val value: String) : Qualifier()
+}
+
+sealed class Scope {
+
+    data object Singleton : Scope()
+
+    /**
+     * Considering a case where user provides a custom annotation:
+     *
+     * ```
+     * @Scope
+     * annotation class Activity
+     * ```
+     *
+     * There are 2 distinct names:
+     * - [originalName] = "Activity". Used in logs.
+     * - [canonicalName] = "activity". Used as the true key.
+     */
+    class Custom(val originalName: String) : Scope() {
+
+        val canonicalName: String = originalName.trim().lowercase()
+
+        override fun toString(): String = originalName
+
+        override fun hashCode(): Int = canonicalName.hashCode()
+
+        override fun equals(other: Any?): Boolean =
+            other is Custom && other.canonicalName == this.canonicalName
+    }
+}

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+/**
+ * Stores useful data to build dependency graph and generate code.
+ *
+ * This shouldn't be an `object` since KSP runs per module inside the Gradle daemon, and
+ * processor classes can live long enough that static state bleeds across compilations.
+ */
+class Registry {
+
+    /**
+     * Represents bindings that are provided via `@Provides`, `@Inject` constructor, and `@Binds`.
+     * Binding requests should lookup here. Bindings that don't exist here are never provided.
+     *
+     * @see BindingPool
+     */
+    val providedBindings = BindingPool<ProvidedBinding>()
+
+    /**
+     * Represents bindings that are requested via field injections. This map collects the
+     * required data to generate DCL instances + `inject(target: T)`.
+     */
+    val requestedBindingsByClass = HashMap<String, ArrayList<RequestedBinding>>()
+
+    /**
+     * Represents bindings that are missing.
+     *
+     * Each contributor will register bindings that are requested but never provided in its module.
+     * The aggregator will append all provided + missing bindings into their respective fields,
+     * then ensure all missing bindings are actually present in [providedBindings].
+     */
+    val missingBindings = HashSet<Binding>()
+
+    /**
+     * Represents whether the current module is the aggregator module.
+     */
+    var isAggregator = false
+}

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -44,7 +44,8 @@ class StitchSymbolProcessor(
 
         logger.info("Stitch: Starting dependency injection code generation")
         try {
-            AnnotationScanner(resolver).scan()
+            val registry = Registry()
+            AnnotationScanner(resolver, logger, registry).scan()
         } catch (e: StitchProcessingException) {
             e.message?.let { logger.error(it, e.symbol) }
             throw e

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Utils.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Utils.kt
@@ -19,7 +19,11 @@ package com.harrytmthy.stitch.compiler
 import com.google.devtools.ksp.symbol.FileLocation
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueArgument
+
+val KSType.qualifiedName: String
+    get() = declaration.qualifiedName!!.asString()
 
 val KSNode.filePathAndLineNumber: String?
     get() = (location as? FileLocation)?.let { "${it.filePath}:${it.lineNumber}" }


### PR DESCRIPTION
### Summary

Refactor AnnotationScanner and internal models to be String-based, preparing Stitch for contributor/aggregator compilation while introducing the new `@StitchRoot` marker.

This PR removes KSType-centric graph construction and centralizes all scanned data into a registry suitable for cross-module aggregation in future work.

### Implementation Details

- Introduce `@StitchRoot` annotation to mark the aggregator compilation unit (not yet used for codegen).
- Add a compiler-side `Registry` to centralize:
  - provided bindings
  - requested bindings
  - missing bindings
  - aggregator detection
- Replace KSType-based binding models with String-based models (`Binding`, `ProvidedBinding`, `RequestedBinding`).
- Introduce `BindingPool` to intern bindings by `(type, qualifier)` while preserving identity.
- Rework `AnnotationScanner` to:
  - resolve scopes via canonical string names
  - support both `@Scope(name = ...)` and meta-annotation scopes (e.g. `@Activity`)
  - normalize scope identity without enforcing FQN uniqueness
  - collect dependencies and missing bindings without building a graph yet

This PR intentionally does **not** introduce contributor aggregation or initializer generation yet, it focuses on correctness, data modeling, and future extensibility.

Closes #77