### PR TITLE
chore: Update Kotlin to 2.3.0 and KSP to 2.3.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,11 +9,11 @@ dagger = "2.54"
 dokka = "2.0.0"
 javaxInject = "1"
 koin = "4.1.1"
-kotlin = "2.2.21"
+kotlin = "2.3.0"
 kotlinBinaryCompatibility = "0.18.1"
 kotlinpoet = "2.2.0"
 kotlinAtomicfu = "0.29.0"
-ksp = "2.2.21-2.0.4"
+ksp = "2.3.4"
 mavenPublishPlugin = "0.32.0"
 
 [libraries]


### PR DESCRIPTION
### Summary

Upgrade Kotlin to 2.3.0 and align KSP to 2.3.4 across the project to keep Stitch compatible with the latest compiler and tooling ecosystem.

Closes #80