### PR TITLE
feat(plugin): Add StitchPlugin for stable moduleName/moduleKey

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,10 @@ android {
             jvmTarget = JvmTarget.JVM_11
         }
     }
+    ksp {
+        arg("stitch.moduleName", "App")
+        arg("stitch.moduleKey", "A1B2C3D4")
+    }
 }
 
 dependencies {

--- a/stitch-compiler/build.gradle.kts
+++ b/stitch-compiler/build.gradle.kts
@@ -16,6 +16,8 @@
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.stitch.publishing)
+    `java-gradle-plugin`
 }
 
 dependencies {
@@ -27,4 +29,20 @@ dependencies {
 
     // Support for Dagger annotations
     compileOnly(libs.javax.inject)
+}
+
+mavenPublishing {
+    pom {
+        name.set("Stitch Compiler")
+        description.set("Stitch KSP compiler and Gradle plugin for module-aware code generation.")
+    }
+}
+
+gradlePlugin {
+    plugins {
+        create("stitchPlugin") {
+            id = "io.github.harrytmthy.stitch"
+            implementationClass = "com.harrytmthy.stitch.compiler.plugin.StitchPlugin"
+        }
+    }
 }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessorProvider.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessorProvider.kt
@@ -28,10 +28,6 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
  */
 class StitchSymbolProcessorProvider : SymbolProcessorProvider {
 
-    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
-        return StitchSymbolProcessor(
-            codeGenerator = environment.codeGenerator,
-            logger = environment.logger,
-        )
-    }
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        StitchSymbolProcessor(environment)
 }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/plugin/StitchPlugin.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/plugin/StitchPlugin.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import java.security.MessageDigest
+
+class StitchPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.pluginManager.withPlugin("com.google.devtools.ksp") {
+            // Configure by extension name to avoid KspExtension class reference
+            val kspExt = project.extensions.findByName("ksp") ?: return@withPlugin
+
+            fun kspArg(key: String, value: String) {
+                val method = kspExt.javaClass.methods.firstOrNull { m ->
+                    m.name == "arg" &&
+                        m.parameterTypes.size == 2 &&
+                        m.parameterTypes[0] == String::class.java &&
+                        m.parameterTypes[1] == String::class.java
+                } ?: error("Unable to find KSP 'arg(String, String)' method. KSP plugin API changed?")
+                method.invoke(kspExt, key, value)
+            }
+
+            // Try to read existing arguments map, if present, to avoid overriding manual config
+            val existingArgs: Map<String, String> =
+                runCatching {
+                    val getter = kspExt.javaClass.methods.firstOrNull { it.name == "getArguments" && it.parameterTypes.isEmpty() }
+                    @Suppress("UNCHECKED_CAST")
+                    (getter?.invoke(kspExt) as? Map<String, String>) ?: emptyMap()
+                }.getOrDefault(emptyMap())
+
+            if (!existingArgs.containsKey("stitch.modulePath")) {
+                kspArg("stitch.modulePath", project.path)
+            }
+            if (!existingArgs.containsKey("stitch.moduleName")) {
+                kspArg("stitch.moduleName", project.path.toPascalModuleName())
+            }
+            if (!existingArgs.containsKey("stitch.moduleKey")) {
+                val length = existingArgs["stitch.moduleKeyLength"]?.toIntOrNull() ?: 8
+                kspArg("stitch.moduleKey", project.path.toStableModuleKey(length))
+            }
+        }
+    }
+
+    private fun String.toPascalModuleName(): String =
+        split(':')
+            .filter { it.isNotBlank() }
+            .joinToString("") { part ->
+                part.split('-', '.', '_')
+                    .filter { it.isNotBlank() }
+                    .joinToString("") { seg ->
+                        seg.replaceFirstChar { if (it.isLowerCase()) it.titlecaseChar() else it }
+                    }
+            }
+            .ifBlank { error("Unable to transform '$this' to pascal case") } // Should not happen
+
+    private fun String.toStableModuleKey(length: Int): String {
+        require(length >= 8 && length % 2 == 0) { "length must be even and >= 8" }
+        val digest = MessageDigest.getInstance("SHA-256").digest(toByteArray())
+        val bytesNeeded = length / 2
+        val key = digest.take(bytesNeeded).joinToString("") { "%02X".format(it) }
+
+        // Package-safe prefix (package segments can't start with digits)
+        return "s$key"
+    }
+}


### PR DESCRIPTION
### Summary

Introduce `io.github.harrytmthy.stitch` Gradle plugin to automatically supply stable `stitch.moduleName` and `stitch.moduleKey` KSP options, and migrate the KSP processor to read options from `SymbolProcessorEnvironment`.

### Implementation Details

- Add `java-gradle-plugin` setup and publish metadata for `:stitch-compiler`.
- Implement `StitchPlugin` that configures KSP args via reflection (no runtime dependency on KSP Gradle classes).
- Refactor `StitchSymbolProcessor` to accept `SymbolProcessorEnvironment` and read `environment.options`.
- Update `:app` to pass `stitch.moduleName` / `stitch.moduleKey` via `ksp { arg(...) }` for CI safety until the plugin is published.

Closes #82