### PR TITLE
feat(annotations): Add @Contribute model for contributor metadata

### DIFF
--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.annotations
+
+@Target(AnnotationTarget.FILE)
+@Retention(AnnotationRetention.BINARY)
+annotation class Contribute(
+    val bindings: Array<ContributedBinding>,
+    val requesters: Array<BindingRequester> = [],
+)
+
+/**
+ * A meta-annotation which represents a binding that is provided and/or requested
+ * in each contributor module.
+ *
+ * Each binding has a locally unique [id] (per contribution) which is used by [dependsOn]
+ * to represent dependencies.
+ */
+annotation class ContributedBinding(
+    val id: Int,
+    val type: String,
+    val qualifier: String = "",
+    val scope: String = "",
+    val provided: Boolean = false,
+)
+
+annotation class BindingRequester(val name: String, val fields: Array<RequestedField>)
+
+annotation class RequestedField(val bindingId: Int, val fieldName: String)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -41,10 +41,14 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
         val logger = environment.logger
         logger.info("Stitch: Starting dependency injection code generation")
         try {
-            val moduleName = getOption("stitch.moduleName")
-            val moduleKey = getOption("stitch.moduleKey")
             val registry = Registry()
             AnnotationScanner(resolver, logger, registry).scan()
+
+            if (!registry.isAggregator) {
+                val moduleName = getOption("stitch.moduleName")
+                val moduleKey = getOption("stitch.moduleKey")
+                // TODO: Generate contribution file
+            }
         } catch (e: StitchProcessingException) {
             e.message?.let { logger.error(it, e.symbol) }
             throw e


### PR DESCRIPTION
### Summary

Introduce the initial `@Contribute` annotation model in `:stitch-annotations` to represent contributor binding metadata, and add a guarded stub in the compiler to read module identifiers for future contributor output generation.

### Implementation Details

- Added `@Contribute` and related annotation types under `:stitch-annotations` to define the contributor metadata schema.
- Updated the compiler to gate contributor-only behavior behind `!registry.isAggregator` and retrieve `stitch.moduleName` and `stitch.moduleKey` as preparation for later code generation.

Closes #79