### PR TITLE
refactor(compiler): Ensure all aliases considered as contributions

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -40,6 +40,7 @@ class ProvidedBinding(
     qualifier: Qualifier?,
     val scope: Scope?,
     val location: String, // File path + line number
+    val alias: Boolean = false,
 ) : Binding(type, qualifier) {
 
     var dependencies: HashSet<Binding>? = null


### PR DESCRIPTION
### Summary

Refine `@Binds` handling so alias bindings are represented in contributor output.

Closes #89