### PR TITLE
feat(compiler): Add location and alias in contributor output

### DIFF
--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
@@ -35,7 +35,8 @@ annotation class ContributedBinding(
     val type: String,
     val qualifier: String = "",
     val scope: String = "",
-    val provided: Boolean = false,
+    val location: String = "",
+    val alias: Boolean = false,
     val dependsOn: IntArray = [],
 )
 

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
@@ -71,7 +71,8 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
                 binding.qualifier?.let { add("qualifier = %S,\n", it.encode()) }
                 if (binding is ProvidedBinding) {
                     binding.scope?.let { add("scope = %S,\n", it) }
-                    add("provided = true,\n")
+                    add("location = \"${binding.location}\",\n")
+                    add("alias = ${binding.alias},\n")
                     binding.dependencies?.map(sortedBindings::getValue)
                         ?.sorted()
                         ?.let { add("dependsOn = intArrayOf(%L),\n", it.joinToString(", ")) }


### PR DESCRIPTION
### Summary

Add `location` and `alias` metadata to `ContributedBinding` to improve aggregator diagnostics and correctly identify alias nodes.

Closes #91