### PR TITLE
feat(compiler): Introduce explicit scope dependencies via @DependsOn

### DIFF
--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/DependsOn.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/DependsOn.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.annotations
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class DependsOn(val scope: KClass<*> = Singleton::class)

--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Scope.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Scope.kt
@@ -61,5 +61,5 @@ package com.harrytmthy.stitch.annotations
  * @see Qualifier
  */
 @Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FIELD)
-@Retention(AnnotationRetention.RUNTIME)
+@Retention(AnnotationRetention.BINARY)
 annotation class Scope(val name: String = "")

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -67,27 +67,21 @@ sealed class Qualifier {
     }
 }
 
+/**
+ * Explanations:
+ * - If a binding uses `@Singleton`, scope = Scope.Singleton
+ * - If a binding uses `@Activity`, scope = Scope.Custom(qualifiedName = "com.something.Activity")
+ * - If a binding uses `@Scope("activity")`, scope = Scope.Custom(value = "activity")
+ */
 sealed class Scope {
 
     data object Singleton : Scope()
 
-    /**
-     * Considering a case where user provides a custom annotation:
-     *
-     * ```
-     * @Scope
-     * annotation class Activity
-     * ```
-     *
-     * There are 2 distinct names:
-     * - [originalName] = "Activity". Used in logs.
-     * - [canonicalName] = "activity". Used as the true key.
-     */
-    class Custom(val originalName: String) : Scope() {
+    class Custom(val qualifiedName: String = "", val value: String = "") : Scope() {
 
-        val canonicalName: String = originalName.trim().lowercase()
+        val canonicalName: String = qualifiedName.ifBlank { value }
 
-        override fun toString(): String = originalName
+        override fun toString(): String = canonicalName
 
         override fun hashCode(): Int = canonicalName.hashCode()
 

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
@@ -48,6 +48,13 @@ class Registry {
     val missingBindings = HashSet<Binding>()
 
     /**
+     * Represents scope dependencies that are registered via `@DependsOn`.
+     * - Key: The registered scope
+     * - Value: Its dependency
+     */
+    val scopeDependencies = HashMap<Scope, Scope>()
+
+    /**
      * Represents whether the current module is the aggregator module.
      */
     var isAggregator = false


### PR DESCRIPTION
### Summary

Introduce explicit scope dependency modeling via `@DependsOn`, and refine how custom scopes are represented and collected on the contributor side.

This change decouples scope *usage* from scope *hierarchy*, allowing scope relationships to be expressed explicitly and transported safely to the aggregator.

### Implementation Details

- Added `@DependsOn` meta-annotation targeting annotation classes to declare upstream scope dependencies.
- Updated `@Scope` retention to `BINARY` and clarified its role as a scope marker or string-based scope label.
- Refined the internal scope model:
  - `Scope.Singleton` for singleton bindings.
  - `Scope.Custom(qualifiedName = ...)` for annotation-based scopes.
  - `Scope.Custom(value = ...)` for string-based scopes.
- Updated `AnnotationScanner` to:
  - Register custom scope annotations by qualified name.
  - Resolve scope usage from either annotation-based or string-based scopes.
  - Collect explicit scope dependency edges declared via `@DependsOn`.
- Added `Registry.scopeDependencies` to store contributor-side scope dependency metadata.

No scope cycle detection or global validation is performed in this PR. These concerns are deferred to the aggregator phase.

Closes #101