### PR TITLE
refactor(compiler): Improve scope modeling and scanning on the contributor side

### DIFF
--- a/samples/core/src/main/kotlin/com/harrytmthy/stitch/core/Scopes.kt
+++ b/samples/core/src/main/kotlin/com/harrytmthy/stitch/core/Scopes.kt
@@ -16,6 +16,7 @@
 
 package com.harrytmthy.stitch.core
 
+import com.harrytmthy.stitch.annotations.DependsOn
 import com.harrytmthy.stitch.annotations.Scope
 
 @Scope
@@ -23,9 +24,11 @@ import com.harrytmthy.stitch.annotations.Scope
 annotation class Activity
 
 @Scope
+@DependsOn(Activity::class)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Fragment
 
 @Scope
+@DependsOn(Fragment::class)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class ViewWithFragment

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -67,19 +67,11 @@ sealed class Qualifier {
     }
 }
 
-/**
- * Explanations:
- * - If a binding uses `@Singleton`, scope = Scope.Singleton
- * - If a binding uses `@Activity`, scope = Scope.Custom(qualifiedName = "com.something.Activity")
- * - If a binding uses `@Scope("activity")`, scope = Scope.Custom(value = "activity")
- */
 sealed class Scope {
 
     data object Singleton : Scope()
 
-    class Custom(val qualifiedName: String = "", val value: String = "") : Scope() {
-
-        val canonicalName: String = qualifiedName.ifBlank { value }
+    class Custom(val canonicalName: String, val qualifiedName: String = "") : Scope() {
 
         override fun toString(): String = canonicalName
 

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
@@ -48,6 +48,11 @@ class Registry {
     val missingBindings = HashSet<Binding>()
 
     /**
+     * Represents custom scopes grouped by their FQN.
+     */
+    val customScopeByQualifiedName = HashMap<String, Scope.Custom>()
+
+    /**
      * Represents scope dependencies that are registered via `@DependsOn`.
      * - Key: The registered scope
      * - Value: Its dependency


### PR DESCRIPTION
### Summary

Refines scope modeling and scanning on the contributor side so that both typed scopes (e.g. `@Activity`) and string scopes (e.g. `@Scope("activity")`) share a single, consistent representation and can participate in explicit scope hierarchies.

Closes #103