### PR TITLE
feat(annotations): Add RegisteredScope to @Contribute

### DIFF
--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
@@ -21,6 +21,7 @@ package com.harrytmthy.stitch.annotations
 annotation class Contribute(
     val bindings: Array<ContributedBinding>,
     val requesters: Array<BindingRequester> = [],
+    val scopes: Array<RegisteredScope> = [],
 )
 
 /**
@@ -43,3 +44,21 @@ annotation class ContributedBinding(
 annotation class BindingRequester(val name: String, val fields: Array<RequestedField>)
 
 annotation class RequestedField(val bindingId: Int, val fieldName: String)
+
+/**
+ * Represents a custom scope that is registered in a contributor module.
+ * Each scope depends on Singleton by default (id = 0).
+ *
+ * The aggregator will register custom scopes and their dependencies using [canonicalName]
+ * as the identifier, while enforcing these rules:
+ * - A registered scope with a non-empty [qualifiedName] will be prioritized.
+ * - If there are more than one scope with same [canonicalName] but different [qualifiedName],
+ *   the aggregator will report them as duplicates + mention each [location] to ease debugging.
+ */
+annotation class RegisteredScope(
+    val id: Int,
+    val canonicalName: String,
+    val qualifiedName: String,
+    val location: String = "",
+    val dependsOn: Int = 0,
+)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/AnnotationScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/AnnotationScanner.kt
@@ -119,7 +119,8 @@ class AnnotationScanner(
                         val qualifiedName = symbol.qualifiedName(symbol)
                         val canonicalName = scopeName.ifBlank { symbol.simpleName.asString() }
                             .lowercase()
-                        val scope = Scope.Custom(canonicalName, qualifiedName)
+                        val location = symbol.filePathAndLineNumber.orEmpty()
+                        val scope = Scope.Custom(canonicalName, qualifiedName, location)
                         registry.customScopeByQualifiedName[qualifiedName] = scope
                         scopeBySymbol[symbol] = scope
                         continue

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Models.kt
@@ -71,7 +71,11 @@ sealed class Scope {
 
     data object Singleton : Scope()
 
-    class Custom(val canonicalName: String, val qualifiedName: String = "") : Scope() {
+    class Custom(
+        val canonicalName: String,
+        val qualifiedName: String = "",
+        val location: String = "",
+    ) : Scope() {
 
         override fun toString(): String = canonicalName
 


### PR DESCRIPTION
### Summary

This PR includes adding a new RegisteredScope DTO to `@Contribute`, which is a mandatory step to add registered custom scopes to `Generated<ModuleName>Contribution.kt`. In addition, `location` is tracked to improve the overall clarity, especially on duplicate scope cases.

Closes #105