### PR TITLE
feat(compiler): Emit registered custom scopes into contributor outputs

### DIFF
--- a/samples/feature/home/src/main/kotlin/com/harrytmthy/stitch/feature/home/HomeViewModel.kt
+++ b/samples/feature/home/src/main/kotlin/com/harrytmthy/stitch/feature/home/HomeViewModel.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.feature.home
+
+import com.harrytmthy.stitch.annotations.Inject
+import com.harrytmthy.stitch.core.Activity
+
+@Activity
+class HomeViewModel @Inject constructor(private val homeService: HomeService) {
+
+    fun fetchHomeData() {
+        homeService.fetch()
+    }
+}

--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
@@ -58,7 +58,7 @@ annotation class RequestedField(val bindingId: Int, val fieldName: String)
 annotation class RegisteredScope(
     val id: Int,
     val canonicalName: String,
-    val qualifiedName: String,
+    val qualifiedName: String = "",
     val location: String = "",
     val dependsOn: Int = 0,
 )

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/AnnotationScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/AnnotationScanner.kt
@@ -121,6 +121,7 @@ class AnnotationScanner(
                             .lowercase()
                         val location = symbol.filePathAndLineNumber.orEmpty()
                         val scope = Scope.Custom(canonicalName, qualifiedName, location)
+                        registry.customScopeByCanonicalName[canonicalName] = scope
                         registry.customScopeByQualifiedName[qualifiedName] = scope
                         scopeBySymbol[symbol] = scope
                         continue
@@ -129,7 +130,11 @@ class AnnotationScanner(
                     if (scopeName.isEmpty()) {
                         fatalError("Scope name cannot be empty", symbol)
                     }
-                    scopeBySymbol[symbol] = Scope.Custom(canonicalName = scopeName.lowercase())
+                    val scope = Scope.Custom(canonicalName = scopeName.lowercase())
+                    if (scope.canonicalName !in registry.customScopeByCanonicalName) {
+                        registry.customScopeByCanonicalName[scope.canonicalName] = scope
+                    }
+                    scopeBySymbol[symbol] = scope
                 }
 
                 is KSFunctionDeclaration -> {
@@ -140,7 +145,11 @@ class AnnotationScanner(
                     if (scopeName.isEmpty()) {
                         fatalError("Scope name cannot be empty", symbol)
                     }
-                    scopeBySymbol[symbol] = Scope.Custom(canonicalName = scopeName.lowercase())
+                    val scope = Scope.Custom(canonicalName = scopeName.lowercase())
+                    if (scope.canonicalName !in registry.customScopeByCanonicalName) {
+                        registry.customScopeByCanonicalName[scope.canonicalName] = scope
+                    }
+                    scopeBySymbol[symbol] = scope
                 }
             }
         }
@@ -167,7 +176,10 @@ class AnnotationScanner(
             val canonicalName = (scopeAnnotation.arguments[0].value as String)
                 .ifBlank { dependency.declaration.simpleName.asString() }
                 .lowercase()
-            val scopeDependency = Scope.Custom(canonicalName, qualifiedName)
+            val scopeDependency = Scope.Custom(canonicalName)
+            if (canonicalName !in registry.customScopeByCanonicalName) {
+                registry.customScopeByCanonicalName[canonicalName] = scopeDependency
+            }
             registry.customScopeByQualifiedName[qualifiedName] = scopeDependency
             registry.scopeDependencies[scope] = scopeDependency
         }
@@ -455,7 +467,10 @@ class AnnotationScanner(
                     val canonicalName = (metaAnnotation.arguments[0].value as String)
                         .ifBlank { annotation.shortName.asString() }
                         .lowercase()
-                    val scope = Scope.Custom(canonicalName, qualifiedName)
+                    val scope = Scope.Custom(canonicalName)
+                    if (canonicalName !in registry.customScopeByCanonicalName) {
+                        registry.customScopeByCanonicalName[canonicalName] = scope
+                    }
                     registry.customScopeByQualifiedName[qualifiedName] = scope
                     scopeBySymbol[symbol] = scope
                     return scope

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/Registry.kt
@@ -48,7 +48,15 @@ class Registry {
     val missingBindings = HashSet<Binding>()
 
     /**
-     * Represents custom scopes grouped by their FQN.
+     * Represents locally registered custom scopes.
+     */
+    val customScopeByCanonicalName = HashMap<String, Scope.Custom>()
+
+    /**
+     * Represents custom scopes grouped by their FQN, which is intended for fast-lookup.
+     *
+     * This includes scopes that are registered via custom annotation (e.g. `@Session`) and
+     * scope dependencies (`@DependsOn(...)`). **Do not use this to query registered scopes!**
      */
     val customScopeByQualifiedName = HashMap<String, Scope.Custom>()
 


### PR DESCRIPTION
### Summary

Emit registered custom scopes into contributor outputs by adding `scopes = [...]` payloads into `@Contribute`, based on locally scanned `@Scope` and `@DependsOn` relationships.

### Implementation Details

- Track locally registered custom scopes keyed by `canonicalName` for deterministic ordering and stable ID assignment.
- Generate `RegisteredScope` entries in contributor outputs:
  - `id` is stable, based on sorted `canonicalName` order, with `0` reserved for Singleton.
  - `dependsOn` references other registered scope IDs when available, otherwise defaults to `0`.
  - `qualifiedName` and `location` are emitted when present to support disambiguation and better error reporting later.

Closes #106