### PR TITLE
feat: Add moduleKey to @Contribute and rename StitchScope to InjectorScope

### DIFF
--- a/samples/app/src/main/java/com/harrytmthy/stitch/ui/MainActivity.kt
+++ b/samples/app/src/main/java/com/harrytmthy/stitch/ui/MainActivity.kt
@@ -10,7 +10,7 @@ import com.harrytmthy.stitch.annotations.Inject
 import com.harrytmthy.stitch.annotations.Named
 import com.harrytmthy.stitch.annotations.Scope
 import com.harrytmthy.stitch.api.Stitch
-import com.harrytmthy.stitch.api.StitchScope
+import com.harrytmthy.stitch.api.InjectorScope
 import com.harrytmthy.stitch.core.Logger
 import com.harrytmthy.stitch.di.ApiService
 import com.harrytmthy.stitch.di.AppModule.BASE_URL
@@ -27,9 +27,6 @@ import com.harrytmthy.stitch.exception.MissingBindingException
  * Only for testing convenience. Please ignore the weird architecture 😄
  */
 class MainActivity : AppCompatActivity() {
-
-    @Scope("activity")
-    lateinit var mainActivityScope: StitchScope
 
     @Inject
     lateinit var logger: Logger

--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
@@ -19,6 +19,7 @@ package com.harrytmthy.stitch.annotations
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
 annotation class Contribute(
+    val moduleKey: String,
     val bindings: Array<ContributedBinding>,
     val requesters: Array<BindingRequester> = [],
     val scopes: Array<RegisteredScope> = [],

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
@@ -30,9 +30,11 @@ import java.security.MessageDigest
 class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
 
     fun generate(moduleName: String, registry: Registry) {
+        val moduleKey = moduleName.toModuleKey()
         val sortedBindings = registry.getSortedBindingsWithId()
         val contributedBindings = buildContributedBindings(sortedBindings)
         val contributeAnnotation = AnnotationSpec.builder(Contribute::class).apply {
+            addMember("moduleKey = %S", moduleKey)
             addMember("bindings = %L", contributedBindings)
             if (registry.requestedBindingsByClass.isNotEmpty()) {
                 val sortedRequestedBindings = registry.getSortedRequestedBindings()
@@ -46,7 +48,6 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
             }
         }.build()
         val packageName = "com.harrytmthy.stitch.generated"
-        val moduleKey = moduleName.toModuleKey()
         val fileName = "Generated${moduleName.toPascalModuleName()}Contribution_$moduleKey"
         val outputObject = TypeSpec.objectBuilder(fileName)
             .addAnnotation(contributeAnnotation)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -36,8 +36,6 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
         if (processed) {
             return emptyList()
         }
-        processed = true
-
         val logger = environment.logger
         logger.info("Stitch: Starting dependency injection code generation")
         try {
@@ -53,6 +51,7 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
             e.message?.let { logger.error(it, e.symbol) }
             throw e
         }
+        processed = true
         return emptyList()
     }
 

--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -6,6 +6,11 @@ public final class com/harrytmthy/stitch/api/Component {
 	public final fun getInternal (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/api/Scope;Lcom/harrytmthy/stitch/api/ResolutionContext;)Ljava/lang/Object;
 }
 
+public abstract interface class com/harrytmthy/stitch/api/InjectorScope {
+	public abstract fun close ()V
+	public abstract fun inject (Ljava/lang/Object;)V
+}
+
 public final class com/harrytmthy/stitch/api/Module {
 	public fun <init> (ZLkotlin/jvm/functions/Function1;)V
 	public final fun define (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLcom/harrytmthy/stitch/api/ScopeRef;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
@@ -69,11 +74,6 @@ public final class com/harrytmthy/stitch/api/Stitch {
 	public final fun reset ()V
 	public final fun unregister ([Lcom/harrytmthy/stitch/api/Module;)V
 	public final fun unregisterAll ()V
-}
-
-public abstract interface class com/harrytmthy/stitch/api/StitchScope {
-	public abstract fun close ()V
-	public abstract fun inject (Ljava/lang/Object;)V
 }
 
 public final class com/harrytmthy/stitch/exception/CycleException : com/harrytmthy/stitch/exception/GetFailedException {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/InjectorScope.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/InjectorScope.kt
@@ -16,7 +16,7 @@
 
 package com.harrytmthy.stitch.api
 
-interface StitchScope {
+interface InjectorScope {
     fun inject(target: Any)
     fun close()
 }


### PR DESCRIPTION
### Summary

This PR includes adding `moduleKey` to `@Contribute` to later create parts of the generated injector scope, as well as renaming StitchScope to InjectorScope. In addition, `processed` flag is moved to the bottom (before returning `emptyList()`) in StitchSymbolProcessor to increase robustness.

Closes #111