### PR TITLE
chore: Update Kotlin to 2.3.10, KSP to 2.3.6, AGP to 9.0.1, and Gradle to 9.3.1

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -29,7 +29,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = "com.android.library")
-            apply(plugin = "org.jetbrains.kotlin.android")
             extensions.configure<LibraryExtension> {
                 compileSdk = 36
                 defaultConfig {

--- a/gradle/init.gradle.kts
+++ b/gradle/init.gradle.kts
@@ -1,7 +1,7 @@
 val ktlintVersion = "1.8.0"
 
 initscript {
-    val spotlessVersion = "7.0.2"
+    val spotlessVersion = "8.2.1"
     repositories {
         mavenCentral()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.13.1"
+androidGradlePlugin = "9.0.1"
 androidxAppcompat = "1.7.1"
 androidxBenchmark = "1.4.1"
 androidxCoreKtx = "1.17.0"
@@ -9,11 +9,11 @@ dagger = "2.54"
 dokka = "2.0.0"
 javaxInject = "1"
 koin = "4.1.1"
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 kotlinBinaryCompatibility = "0.18.1"
 kotlinpoet = "2.2.0"
 kotlinAtomicfu = "0.29.0"
-ksp = "2.3.4"
+ksp = "2.3.6"
 mavenPublishPlugin = "0.32.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 26 14:04:15 WIB 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/app/build.gradle.kts
+++ b/samples/app/build.gradle.kts
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     alias(libs.plugins.ksp)
 }
 


### PR DESCRIPTION
### Summary

This PR updates the build toolchain:

- Kotlin → 2.3.10
- KSP → 2.3.6
- AGP → 9.0.1
- Gradle → 9.3.1

In addition, Spotless is also updated to 8.2.1

Closes #113