### PR TITLE
feat(compiler): Collect requested bindings from @Contribute metadata

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
@@ -20,6 +20,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.harrytmthy.stitch.annotations.Contribute
 import com.harrytmthy.stitch.compiler.StitchSymbolProcessor.Companion.GENERATED_PACKAGE_NAME
+import com.harrytmthy.stitch.compiler.scanner.LocalScanResult
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -29,22 +30,22 @@ import java.io.OutputStreamWriter
 
 class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
 
-    fun generate(moduleName: String, moduleKey: String, registry: Registry) {
-        val sortedBindings = registry.getSortedBindingsWithId()
+    fun generate(moduleName: String, moduleKey: String, localScanResult: LocalScanResult) {
+        val sortedBindings = localScanResult.getSortedBindingsWithId()
         val contributedBindings = buildContributedBindings(sortedBindings)
         val contributeAnnotation = AnnotationSpec.builder(Contribute::class).apply {
             addMember("moduleKey = %S", moduleKey)
             addMember("bindings = %L", contributedBindings)
-            if (registry.requestedBindingsByClass.isNotEmpty()) {
-                val sortedRequestedBindings = registry.getSortedRequestedBindings()
+            if (localScanResult.requestedBindingsByClass.isNotEmpty()) {
+                val sortedRequestedBindings = localScanResult.getSortedRequestedBindings()
                 val requesters = buildBindingRequesters(sortedBindings, sortedRequestedBindings)
                 addMember("requesters = %L", requesters)
             } else {
                 addMember("requesters = []")
             }
-            if (registry.customScopeByCanonicalName.isNotEmpty()) {
-                val sortedCustomScopes = registry.getSortedRegisteredScopesWithId()
-                val scopes = buildRegisteredScopes(sortedCustomScopes, registry.scopeDependencies)
+            if (localScanResult.customScopeByCanonicalName.isNotEmpty()) {
+                val sortedCustomScopes = localScanResult.getSortedRegisteredScopesWithId()
+                val scopes = buildRegisteredScopes(sortedCustomScopes, localScanResult.scopeDependencies)
                 addMember("scopes = %L", scopes)
             } else {
                 addMember("scopes = []")
@@ -177,7 +178,7 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
      * - provided bindings + their dependencies
      * - requested bindings
      */
-    private fun Registry.getSortedBindingsWithId(): Map<Binding, Int> {
+    private fun LocalScanResult.getSortedBindingsWithId(): Map<Binding, Int> {
         val bindings = LinkedHashSet<Binding>()
         bindings += providedBindings.values
         providedBindings.values.forEach { it.dependencies?.let(bindings::addAll) }
@@ -191,7 +192,7 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
     /**
      * Produces stable ordering for Gradle cache hits.
      */
-    private fun Registry.getSortedRequestedBindings(): Map<String, List<RequestedBinding>> =
+    private fun LocalScanResult.getSortedRequestedBindings(): Map<String, List<RequestedBinding>> =
         requestedBindingsByClass.toSortedMap() // sort by requester's FQN
             .mapValues { (_, fields) ->
                 val comparator = compareBy<RequestedBinding>(
@@ -205,7 +206,7 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
     /**
      * Returns sorted bindings by stable IDs.
      */
-    private fun Registry.getSortedRegisteredScopesWithId(): Map<Scope.Custom, Int> {
+    private fun LocalScanResult.getSortedRegisteredScopesWithId(): Map<Scope.Custom, Int> {
         var nextId = 1
         return customScopeByCanonicalName.values.sortedWith(compareBy { it.canonicalName })
             .associateWith { nextId++ }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -22,6 +22,7 @@ import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.harrytmthy.stitch.compiler.scanner.ContributionScanner
 import com.harrytmthy.stitch.compiler.scanner.LocalAnnotationScanner
+import com.harrytmthy.stitch.compiler.scanner.LocalScanResult
 import java.security.MessageDigest
 
 /**
@@ -44,13 +45,13 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
         try {
             val moduleName = getOption("stitch.moduleName")
             val moduleKey = moduleName.toModuleKey()
-            val registry = Registry()
-            LocalAnnotationScanner(resolver, moduleKey, registry).scan()
-            if (!registry.isAggregator) {
+            val localScanResult = LocalScanResult()
+            LocalAnnotationScanner(resolver, moduleKey, localScanResult).scan()
+            if (!localScanResult.isAggregator) {
                 ContributionCodeGenerator(environment.codeGenerator)
-                    .generate(moduleName, moduleKey, registry)
+                    .generate(moduleName, moduleKey, localScanResult)
             } else {
-                ContributionScanner(resolver, registry).scan()
+                ContributionScanner(resolver, moduleKey, localScanResult).scan()
                 // TODO: Add scope graph builder
                 // TODO: Add binding graph builder
                 // TODO: Add codegen for InjectorScope's implementation

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
@@ -20,67 +20,95 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.harrytmthy.stitch.annotations.Contribute
-import com.harrytmthy.stitch.compiler.Registry
+import com.harrytmthy.stitch.compiler.Binding
+import com.harrytmthy.stitch.compiler.ProvidedBinding
+import com.harrytmthy.stitch.compiler.Qualifier
+import com.harrytmthy.stitch.compiler.RequestedBinding
+import com.harrytmthy.stitch.compiler.Scope
 import com.harrytmthy.stitch.compiler.StitchSymbolProcessor.Companion.GENERATED_PACKAGE_NAME
 
 class ContributionScanner(
     private val resolver: Resolver,
-    private val registry: Registry,
+    private val moduleKey: String,
+    private val scanResult: LocalScanResult,
 ) {
 
     @OptIn(KspExperimental::class)
     @Suppress("UNCHECKED_CAST")
     fun scan() {
+        val providedBindings = HashMap(scanResult.providedBindings)
+        val requestedBindingsByModuleKey = HashMap<String, Map<String, List<RequestedBinding>>>()
+        requestedBindingsByModuleKey[moduleKey] = HashMap(scanResult.requestedBindingsByClass)
         for (declaration in resolver.getDeclarationsFromPackage(GENERATED_PACKAGE_NAME)) {
             val annotation = declaration.annotations
                 .find { it.shortName.asString() == Contribute::class.simpleName }
                 ?: continue
             val moduleKey = annotation.arguments[0].value as String
             val bindingAnnotations = annotation.arguments[1].value as List<KSAnnotation>
+            val requesterAnnotations = annotation.arguments[2].value as List<KSAnnotation>
+            val scopeAnnotations = annotation.arguments[3].value as List<KSAnnotation>
+
+            // Step 1: Collect all provided + requested bindings from the aggregator & contributors
+            val localBindings = ArrayList<Binding>()
             for (bindingAnnotation in bindingAnnotations) {
                 val id = bindingAnnotation.arguments[0].value as Int
                 val type = bindingAnnotation.arguments[1].value as String
-                val qualifier = bindingAnnotation.arguments[2].value as String
+                val qualifier = Qualifier.of(bindingAnnotation.arguments[2].value as String)
                 val scope = bindingAnnotation.arguments[3].value as String
                 val location = bindingAnnotation.arguments[4].value as String
                 val alias = bindingAnnotation.arguments[5].value as Boolean
                 val dependsOn = bindingAnnotation.arguments[6].value as List<Int>
-
-                // TODO: For provided bindings, check for duplicates then collect it under a new ID.
-
-                // TODO: For requested bindings, put it into a separate collection.
+                val bindingKey = Binding(type, qualifier)
+                localBindings.add(bindingKey)
+                if (location.isNotEmpty()) {
+                    // ProvidedBinding path
+                    if (bindingKey in providedBindings) {
+                        // TODO(#120): Throw duplicate binding exception
+                    }
+                    val scope = when (scope) {
+                        "Singleton" -> Scope.Singleton
+                        "" -> null
+                        else -> Scope.Custom(scope)
+                    }
+                    val binding = ProvidedBinding(type, qualifier, scope, location, alias, moduleKey)
+                    providedBindings[bindingKey] = binding
+                }
             }
 
-            // TODO: Traverse the requested + 'local missing' bindings to ensure they are provided.
-
-            // TODO: Traverse the provided bindings to build graph edges using dependsOn.
-
-            val requesterAnnotations = annotation.arguments[2].value as List<KSAnnotation>
+            // Step 2: Collect all requesters, grouped by moduleKey
+            val requestedBindingsByRequester = HashMap<String, List<RequestedBinding>>()
             for (requesterAnnotation in requesterAnnotations) {
                 val requesterQualifiedName = requesterAnnotation.arguments[0].value as String
                 val fields = requesterAnnotation.arguments[1].value as List<KSAnnotation>
+                val requestedBindings = ArrayList<RequestedBinding>(fields.size)
                 for (field in fields) {
                     val bindingId = field.arguments[0].value as Int
                     val fieldName = field.arguments[1].value as String
-
-                    // TODO: Collect all fields, grouped by requesterQualifiedName.
-                    //       This collection will be used to generate `inject(target: T)`.
+                    val binding = localBindings[bindingId - 1] // -1 since ID starts from 1
+                    if (binding !in providedBindings) {
+                        // TODO(#120): Throw missing binding exception
+                    }
+                    val requestedBinding = RequestedBinding(binding.type, binding.qualifier, fieldName)
+                    requestedBindings.add(requestedBinding)
+                    requestedBindingsByRequester[requesterQualifiedName] = requestedBindings
                 }
-
-                // TODO: Collect all requesters, grouped by moduleKey
-                //       This collection will be used to generate `Part<ModuleKey> class`
             }
+            requestedBindingsByModuleKey[moduleKey] = requestedBindingsByRequester
 
-            val scopeAnnotations = annotation.arguments[3].value as List<KSAnnotation>
+            // Step 3: Collect all scopes
             for (scopeAnnotation in scopeAnnotations) {
                 val id = scopeAnnotation.arguments[0].value as Int
                 val canonicalName = scopeAnnotation.arguments[1].value as String
                 val qualifiedName = scopeAnnotation.arguments[2].value as String
                 val location = scopeAnnotation.arguments[3].value as String
                 val dependsOn = scopeAnnotation.arguments[4].value as Int
-
-                // TODO: Build scope edges using dependsOn
             }
+
+            // Step 4: Build binding edges
+            // TODO(#120): Implement this step
+
+            // Step 5: Build scope edges
+            // TODO(#124): Implement this step
         }
     }
 }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
@@ -30,7 +30,6 @@ import com.harrytmthy.stitch.compiler.Binding
 import com.harrytmthy.stitch.compiler.BindingPool
 import com.harrytmthy.stitch.compiler.ProvidedBinding
 import com.harrytmthy.stitch.compiler.Qualifier
-import com.harrytmthy.stitch.compiler.Registry
 import com.harrytmthy.stitch.compiler.RequestedBinding
 import com.harrytmthy.stitch.compiler.Scope
 import com.harrytmthy.stitch.compiler.fatalError
@@ -42,7 +41,7 @@ import com.harrytmthy.stitch.compiler.qualifiedName
 class LocalAnnotationScanner(
     private val resolver: Resolver,
     private val moduleKey: String,
-    private val registry: Registry,
+    private val scanResult: LocalScanResult,
 ) {
 
     private val scopeBySymbol = HashMap<KSAnnotated, Scope>()
@@ -67,7 +66,7 @@ class LocalAnnotationScanner(
     }
 
     private fun scanRoot() {
-        registry.isAggregator = resolver.getSymbolsWithAnnotation(ROOT).any()
+        scanResult.isAggregator = resolver.getSymbolsWithAnnotation(ROOT).any()
     }
 
     /**
@@ -132,8 +131,8 @@ class LocalAnnotationScanner(
                             .lowercase()
                         val location = symbol.filePathAndLineNumber.orEmpty()
                         val scope = Scope.Custom(canonicalName, qualifiedName, location)
-                        registry.customScopeByCanonicalName[canonicalName] = scope
-                        registry.customScopeByQualifiedName[qualifiedName] = scope
+                        scanResult.customScopeByCanonicalName[canonicalName] = scope
+                        scanResult.customScopeByQualifiedName[qualifiedName] = scope
                         scopeBySymbol[symbol] = scope
                         continue
                     }
@@ -142,8 +141,8 @@ class LocalAnnotationScanner(
                         fatalError("Scope name cannot be empty", symbol)
                     }
                     val scope = Scope.Custom(canonicalName = scopeName.lowercase())
-                    if (scope.canonicalName !in registry.customScopeByCanonicalName) {
-                        registry.customScopeByCanonicalName[scope.canonicalName] = scope
+                    if (scope.canonicalName !in scanResult.customScopeByCanonicalName) {
+                        scanResult.customScopeByCanonicalName[scope.canonicalName] = scope
                     }
                     scopeBySymbol[symbol] = scope
                 }
@@ -157,8 +156,8 @@ class LocalAnnotationScanner(
                         fatalError("Scope name cannot be empty", symbol)
                     }
                     val scope = Scope.Custom(canonicalName = scopeName.lowercase())
-                    if (scope.canonicalName !in registry.customScopeByCanonicalName) {
-                        registry.customScopeByCanonicalName[scope.canonicalName] = scope
+                    if (scope.canonicalName !in scanResult.customScopeByCanonicalName) {
+                        scanResult.customScopeByCanonicalName[scope.canonicalName] = scope
                     }
                     scopeBySymbol[symbol] = scope
                 }
@@ -173,12 +172,12 @@ class LocalAnnotationScanner(
             val annotation = symbol.annotations.find(DEPENDS_ON)
             val dependency = annotation.arguments[0].value as KSType
             val qualifiedName = dependency.declaration.qualifiedName(symbol)
-            registry.customScopeByQualifiedName[qualifiedName]?.let { dependency ->
-                registry.scopeDependencies[scope] = dependency
+            scanResult.customScopeByQualifiedName[qualifiedName]?.let { dependency ->
+                scanResult.scopeDependencies[scope] = dependency
                 continue
             }
             if (qualifiedName == STITCH_SINGLETON || qualifiedName == JAVAX_SINGLETON) {
-                registry.scopeDependencies[scope] = Scope.Singleton
+                scanResult.scopeDependencies[scope] = Scope.Singleton
                 continue
             }
             val scopeAnnotation = dependency.declaration.annotations.find {
@@ -188,11 +187,11 @@ class LocalAnnotationScanner(
                 .ifBlank { dependency.declaration.simpleName.asString() }
                 .lowercase()
             val scopeDependency = Scope.Custom(canonicalName)
-            if (canonicalName !in registry.customScopeByCanonicalName) {
-                registry.customScopeByCanonicalName[canonicalName] = scopeDependency
+            if (canonicalName !in scanResult.customScopeByCanonicalName) {
+                scanResult.customScopeByCanonicalName[canonicalName] = scopeDependency
             }
-            registry.customScopeByQualifiedName[qualifiedName] = scopeDependency
-            registry.scopeDependencies[scope] = scopeDependency
+            scanResult.customScopeByQualifiedName[qualifiedName] = scopeDependency
+            scanResult.scopeDependencies[scope] = scopeDependency
         }
     }
 
@@ -227,11 +226,11 @@ class LocalAnnotationScanner(
 
             // ProvidedBinding is keyed only by type + qualifier, allowing `providedBindings`
             // to detect if there is another symbol providing the same type + qualifier.
-            if (binding in registry.providedBindings) {
-                duplicateBindingError(registry.providedBindings.getValue(binding), symbol)
+            if (binding in scanResult.providedBindings) {
+                duplicateBindingError(scanResult.providedBindings.getValue(binding), symbol)
             }
             providedBindingBySymbol[symbol] = binding
-            registry.providedBindings.add(binding)
+            scanResult.providedBindings.add(binding)
 
             // Parameters (or "dependencies") that will be collected after scanning @Inject.
             if (symbol.parameters.isNotEmpty()) {
@@ -279,11 +278,11 @@ class LocalAnnotationScanner(
 
         // ProvidedBinding is keyed only by type + qualifier, allowing `providedBindings`
         // to detect if there is another symbol providing the same type + qualifier.
-        if (binding in registry.providedBindings) {
-            duplicateBindingError(registry.providedBindings.getValue(binding), canonicalSymbol)
+        if (binding in scanResult.providedBindings) {
+            duplicateBindingError(scanResult.providedBindings.getValue(binding), canonicalSymbol)
         }
         providedBindingBySymbol[canonicalSymbol] = binding
-        registry.providedBindings.add(binding)
+        scanResult.providedBindings.add(binding)
 
         // Parameters (or "dependencies") that will be collected after scanning @Inject.
         if (symbol.parameters.isNotEmpty()) {
@@ -307,17 +306,17 @@ class LocalAnnotationScanner(
         val fieldName = symbol.simpleName.asString()
         val binding = RequestedBinding(type, qualifier, fieldName)
         val parentQualifiedName = symbol.parentDeclaration!!.qualifiedName!!.asString()
-        val bindings = registry.requestedBindingsByClass.getOrPut(parentQualifiedName) { ArrayList() }
+        val bindings = scanResult.requestedBindingsByClass.getOrPut(parentQualifiedName) { ArrayList() }
         bindings.add(binding)
     }
 
     /**
-     * After scanning types + qualifiers, [Registry.providedBindings] is finalized and can be used
-     * to check if there is any dependency that is not locally provided (or "missing bindings").
+     * After scanning types + qualifiers, [LocalScanResult.providedBindings] is finalized and can be
+     * used to check if there is any dependency that is not locally provided (or missing bindings).
      *
      * Missing bindings will be thrown by the aggregator after collecting all provided bindings
-     * from its contributors + recheck if all elements in [Registry.missingBindings] exist inside
-     * the combined [Registry.providedBindings].
+     * from its contributors + recheck if all elements in [LocalScanResult.missingBindings] exist
+     * inside the combined [LocalScanResult.providedBindings].
      */
     private fun collectDependenciesAndMissingBindings() {
         for ((providedBinding, parameters) in parametersByBinding) {
@@ -328,23 +327,23 @@ class LocalAnnotationScanner(
                 val dependencies = providedBinding.dependencies
                     ?: HashSet<Binding>(parameters.size, 1f).also { providedBinding.dependencies = it }
                 dependencies.add(binding)
-                if (binding !in registry.providedBindings) {
-                    registry.missingBindings.add(binding)
+                if (binding !in scanResult.providedBindings) {
+                    scanResult.missingBindings.add(binding)
                 }
             }
         }
-        for ((_, requestedBindings) in registry.requestedBindingsByClass) {
+        for ((_, requestedBindings) in scanResult.requestedBindingsByClass) {
             for (requestedBinding in requestedBindings) {
-                if (requestedBinding !in registry.providedBindings) {
-                    registry.missingBindings.add(requestedBinding)
+                if (requestedBinding !in scanResult.providedBindings) {
+                    scanResult.missingBindings.add(requestedBinding)
                 }
             }
         }
         for ((_, alias) in providedAliases) {
             // Aliases are guaranteed to have exactly 1 dependency
             val dependency = alias.dependencies!!.single()
-            if (dependency !in registry.providedBindings) {
-                registry.missingBindings.add(dependency)
+            if (dependency !in scanResult.providedBindings) {
+                scanResult.missingBindings.add(dependency)
             }
         }
     }
@@ -472,7 +471,7 @@ class LocalAnnotationScanner(
         }
         alias.dependencies = hashSetOf(dependency)
         providedAliases[alias] = alias
-        registry.providedBindings[alias] = alias
+        scanResult.providedBindings[alias] = alias
     }
 
     /**
@@ -486,7 +485,7 @@ class LocalAnnotationScanner(
         for (annotation in symbol.annotations) {
             val declaration = annotation.annotationType.resolve().declaration
             val qualifiedName = declaration.qualifiedName(symbol)
-            registry.customScopeByQualifiedName[qualifiedName]?.let { return it }
+            scanResult.customScopeByQualifiedName[qualifiedName]?.let { return it }
             for (metaAnnotation in declaration.annotations) {
                 val fqn = metaAnnotation.annotationType.resolve().declaration.qualifiedName(symbol)
                 if (fqn == SCOPE) {
@@ -494,10 +493,10 @@ class LocalAnnotationScanner(
                         .ifBlank { annotation.shortName.asString() }
                         .lowercase()
                     val scope = Scope.Custom(canonicalName)
-                    if (canonicalName !in registry.customScopeByCanonicalName) {
-                        registry.customScopeByCanonicalName[canonicalName] = scope
+                    if (canonicalName !in scanResult.customScopeByCanonicalName) {
+                        scanResult.customScopeByCanonicalName[canonicalName] = scope
                     }
-                    registry.customScopeByQualifiedName[qualifiedName] = scope
+                    scanResult.customScopeByQualifiedName[qualifiedName] = scope
                     scopeBySymbol[symbol] = scope
                     return scope
                 }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalScanResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Harry Timothy Tumalewa
+ * Copyright 2026 Harry Timothy Tumalewa
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,25 @@
  * limitations under the License.
  */
 
-package com.harrytmthy.stitch.compiler
+package com.harrytmthy.stitch.compiler.scanner
+
+import com.harrytmthy.stitch.compiler.Binding
+import com.harrytmthy.stitch.compiler.BindingPool
+import com.harrytmthy.stitch.compiler.ProvidedBinding
+import com.harrytmthy.stitch.compiler.RequestedBinding
+import com.harrytmthy.stitch.compiler.Scope
 
 /**
- * Stores useful data to build dependency graph and generate code.
+ * Stores useful local data to build dependency graph and generate code.
  *
  * This shouldn't be an `object` since KSP runs per module inside the Gradle daemon, and
  * processor classes can live long enough that static state bleeds across compilations.
  */
-class Registry {
+class LocalScanResult {
 
     /**
      * Represents bindings that are provided via `@Provides`, `@Inject` constructor, and `@Binds`.
-     * Binding requests should lookup here. Bindings that don't exist here are never provided.
+     * Binding requests should look up here. Bindings that don't exist here are never provided.
      *
      * @see BindingPool
      */


### PR DESCRIPTION
### Summary

This PR renames the compiler-side `Registry` to `LocalScanResult` to clarify that it represents local module scanning output. It also extends `ContributionScanner` to parse `@Contribute.requesters` and resolve requested field binding IDs to their corresponding binding keys, laying the groundwork for missing-binding validation and injector codegen.

Closes #122