### PR TITLE
feat(compiler): Build registered scope edges

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
@@ -103,15 +103,27 @@ sealed class Qualifier {
 
 sealed class Scope {
 
-    data object Singleton : Scope()
+    abstract val canonicalName: String
+
+    object Singleton : Scope() {
+
+        override val canonicalName: String = "singleton"
+
+        override fun toString(): String = canonicalName
+
+        override fun hashCode(): Int = canonicalName.hashCode()
+
+        override fun equals(other: Any?): Boolean =
+            other is Singleton && other.canonicalName == this.canonicalName
+    }
 
     class Custom(
-        val canonicalName: String,
+        override val canonicalName: String,
         val qualifiedName: String = "",
         val location: String = "",
     ) : Scope() {
 
-        override fun toString(): String = canonicalName
+        override fun toString(): String = qualifiedName.ifBlank { canonicalName }
 
         override fun hashCode(): Int = canonicalName.hashCode()
 

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanResult.kt
@@ -19,6 +19,7 @@ package com.harrytmthy.stitch.compiler.scanner
 import com.harrytmthy.stitch.compiler.model.Binding
 import com.harrytmthy.stitch.compiler.model.ProvidedBinding
 import com.harrytmthy.stitch.compiler.model.RequestedBinding
+import com.harrytmthy.stitch.compiler.model.Scope
 
 sealed class ContributionScanResult {
 
@@ -27,5 +28,7 @@ sealed class ContributionScanResult {
     data class Success(
         val providedBindings: Map<Binding, ProvidedBinding>,
         val requestedBindingsByModuleKey: Map<String, Map<String, List<RequestedBinding>>>,
+        val customScopeByCanonicalName: Map<String, Scope.Custom>,
+        val scopeDependencies: Map<Scope, Scope>,
     ) : ContributionScanResult()
 }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
@@ -39,11 +39,14 @@ class ContributionScanner(
     @OptIn(KspExperimental::class)
     @Suppress("UNCHECKED_CAST")
     fun scan(): ContributionScanResult {
+        // Step 1: Collect all bindings and scopes from the aggregator
         val providedBindings = HashMap(scanResult.providedBindings)
         val requestedBindingsByModuleKey = HashMap<String, Map<String, List<RequestedBinding>>>()
         requestedBindingsByModuleKey[moduleKey] = HashMap(scanResult.requestedBindingsByClass)
+        val customScopeByCanonicalName = HashMap<String, Scope.Custom>(scanResult.customScopeByCanonicalName)
+        val scopeDependencies = HashMap<Scope, Scope>(scanResult.scopeDependencies)
 
-        // Step 1: Collect all contributed bindings and scopes
+        // Step 2: Collect all bindings and scopes from the contributors
         val contributedBindings = ArrayList<BindingDeclaration>()
         val contributedDependencies = ArrayList<List<Int>>() // Flattened indices, NOT bindingId
         for (declaration in resolver.getDeclarationsFromPackage(GENERATED_PACKAGE_NAME)) {
@@ -55,7 +58,7 @@ class ContributionScanner(
             val requesterAnnotations = annotation.arguments[2].value as List<KSAnnotation>
             val scopeAnnotations = annotation.arguments[3].value as List<KSAnnotation>
 
-            // Step 1.1: Collect all provided + requested bindings from the contributors
+            // Step 2.1: Collect all provided + requested bindings from the contributors
             val lastBindingIndex = contributedBindings.lastIndex
             for (bindingAnnotation in bindingAnnotations) {
                 val id = bindingAnnotation.arguments[0].value as Int
@@ -93,7 +96,7 @@ class ContributionScanner(
                 }
             }
 
-            // Step 1.2: Collect all requesters, grouped by moduleKey
+            // Step 2.2: Collect all requesters, grouped by moduleKey
             val requestedBindingsByRequester = HashMap<String, List<RequestedBinding>>()
             for (requesterAnnotation in requesterAnnotations) {
                 val requesterQualifiedName = requesterAnnotation.arguments[0].value as String
@@ -115,20 +118,50 @@ class ContributionScanner(
             }
             requestedBindingsByModuleKey[moduleKey] = requestedBindingsByRequester
 
-            // Step 1.3: Collect all scopes
+            // Step 2.3: Collect all scopes
+            val localScopes = ArrayList<Scope.Custom>(scopeAnnotations.size)
+            val localScopeDependencyIndices = ArrayList<Int>(scopeAnnotations.size)
             for (scopeAnnotation in scopeAnnotations) {
                 val id = scopeAnnotation.arguments[0].value as Int
                 val canonicalName = scopeAnnotation.arguments[1].value as String
                 val qualifiedName = scopeAnnotation.arguments[2].value as String
                 val location = scopeAnnotation.arguments[3].value as String
                 val dependsOn = scopeAnnotation.arguments[4].value as Int
+                customScopeByCanonicalName[canonicalName]?.let { scope ->
+                    // Existing scope path
+                    if (scope.qualifiedName.isNotEmpty() && qualifiedName.isNotEmpty()) {
+                        // There is more than 1 annotation class (for scope) with a same name
+                        logger.error("Duplicate scope: $scope. Already provided at ${scope.location}")
+                    }
+                    if (qualifiedName.isEmpty()) {
+                        // Avoid scope re-registration, unless it's an annotation class declaration
+                        continue
+                    }
+                }
+                val registeredScope = Scope.Custom(canonicalName, qualifiedName, location)
+                customScopeByCanonicalName[canonicalName] = registeredScope
+                localScopes.add(registeredScope)
+                localScopeDependencyIndices.add(dependsOn - 1) // -1 since ID starts from 1
+            }
+
+            // Step 2.4: Collect scope dependencies
+            for (index in localScopes.indices) {
+                val scope = localScopes[index]
+                val dependencyIndex = localScopeDependencyIndices[index]
+                if (dependencyIndex == -1) {
+                    // Singleton path (scopeId = 0 - 1 = -1)
+                    scopeDependencies[scope] = Scope.Singleton
+                } else {
+                    // Custom scope path
+                    scopeDependencies[scope] = localScopes[dependencyIndex]
+                }
             }
         }
         if (logger.hasError) {
             return ContributionScanResult.Error
         }
 
-        // Step 2: Ensure all requested bindings are actually provided
+        // Step 3: Ensure all requested bindings are actually provided
         for (requestedBindingsByRequester in requestedBindingsByModuleKey.values) {
             for (requestedBindings in requestedBindingsByRequester.values) {
                 for (requestedBinding in requestedBindings) {
@@ -142,7 +175,7 @@ class ContributionScanner(
             return ContributionScanResult.Error
         }
 
-        // Step 3: Build binding edges
+        // Step 4: Build binding edges
         for (index in contributedBindings.indices) {
             val binding = contributedBindings[index]
             val dependencies = contributedDependencies[index]
@@ -155,10 +188,12 @@ class ContributionScanner(
             }
         }
 
-        // Step 4: Build scope edges
-        // TODO(#126): Implement this step
-
-        return ContributionScanResult.Success(providedBindings, requestedBindingsByModuleKey)
+        return ContributionScanResult.Success(
+            providedBindings,
+            requestedBindingsByModuleKey,
+            customScopeByCanonicalName,
+            scopeDependencies,
+        )
     }
 
     private fun duplicateBindingError(existing: ProvidedBinding) {

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
@@ -47,6 +47,8 @@ class LocalAnnotationScanner(
 
     private val scopeBySymbol = HashMap<KSAnnotated, Scope>()
 
+    private val customScopeByQualifiedName = HashMap<String, Scope.Custom>()
+
     private val qualifierBySymbol = HashMap<KSAnnotated, Qualifier>()
 
     private val providedBindingBySymbol = HashMap<KSAnnotated, ProvidedBinding>()
@@ -127,13 +129,22 @@ class LocalAnnotationScanner(
                 is KSClassDeclaration -> {
                     if (symbol.classKind == ClassKind.ANNOTATION_CLASS) {
                         // Case #1 path: Register both FQN + canonical name
-                        val qualifiedName = symbol.qualifiedName(symbol)
                         val canonicalName = scopeName.ifBlank { symbol.simpleName.asString() }
                             .lowercase()
+                        if (canonicalName == "singleton") {
+                            fatalError("@Singleton already exists!", symbol)
+                        }
+                        scanResult.customScopeByCanonicalName[canonicalName]?.let {
+                            fatalError(
+                                message = "Duplicate scope: $it. Already provided at ${it.location}",
+                                symbol = symbol,
+                            )
+                        }
+                        val qualifiedName = symbol.qualifiedName(symbol)
                         val location = symbol.filePathAndLineNumber.orEmpty()
                         val scope = Scope.Custom(canonicalName, qualifiedName, location)
                         scanResult.customScopeByCanonicalName[canonicalName] = scope
-                        scanResult.customScopeByQualifiedName[qualifiedName] = scope
+                        customScopeByQualifiedName[qualifiedName] = scope
                         scopeBySymbol[symbol] = scope
                         continue
                     }
@@ -141,7 +152,12 @@ class LocalAnnotationScanner(
                     if (scopeName.isEmpty()) {
                         fatalError("Scope name cannot be empty", symbol)
                     }
-                    val scope = Scope.Custom(canonicalName = scopeName.lowercase())
+                    val canonicalName = scopeName.lowercase()
+                    if (canonicalName == "singleton") {
+                        scopeBySymbol[symbol] = Scope.Singleton
+                        continue
+                    }
+                    val scope = Scope.Custom(canonicalName)
                     if (scope.canonicalName !in scanResult.customScopeByCanonicalName) {
                         scanResult.customScopeByCanonicalName[scope.canonicalName] = scope
                     }
@@ -156,7 +172,12 @@ class LocalAnnotationScanner(
                     if (scopeName.isEmpty()) {
                         fatalError("Scope name cannot be empty", symbol)
                     }
-                    val scope = Scope.Custom(canonicalName = scopeName.lowercase())
+                    val canonicalName = scopeName.lowercase()
+                    if (canonicalName == "singleton") {
+                        scopeBySymbol[symbol] = Scope.Singleton
+                        continue
+                    }
+                    val scope = Scope.Custom(canonicalName)
                     if (scope.canonicalName !in scanResult.customScopeByCanonicalName) {
                         scanResult.customScopeByCanonicalName[scope.canonicalName] = scope
                     }
@@ -173,7 +194,7 @@ class LocalAnnotationScanner(
             val annotation = symbol.annotations.find(DEPENDS_ON)
             val dependency = annotation.arguments[0].value as KSType
             val qualifiedName = dependency.declaration.qualifiedName(symbol)
-            scanResult.customScopeByQualifiedName[qualifiedName]?.let { dependency ->
+            customScopeByQualifiedName[qualifiedName]?.let { dependency ->
                 scanResult.scopeDependencies[scope] = dependency
                 continue
             }
@@ -191,7 +212,7 @@ class LocalAnnotationScanner(
             if (canonicalName !in scanResult.customScopeByCanonicalName) {
                 scanResult.customScopeByCanonicalName[canonicalName] = scopeDependency
             }
-            scanResult.customScopeByQualifiedName[qualifiedName] = scopeDependency
+            customScopeByQualifiedName[qualifiedName] = scopeDependency
             scanResult.scopeDependencies[scope] = scopeDependency
         }
     }
@@ -547,7 +568,7 @@ class LocalAnnotationScanner(
         for (annotation in symbol.annotations) {
             val declaration = annotation.annotationType.resolve().declaration
             val qualifiedName = declaration.qualifiedName(symbol)
-            scanResult.customScopeByQualifiedName[qualifiedName]?.let { return it }
+            customScopeByQualifiedName[qualifiedName]?.let { return it }
             for (metaAnnotation in declaration.annotations) {
                 val fqn = metaAnnotation.annotationType.resolve().declaration.qualifiedName(symbol)
                 if (fqn == SCOPE) {
@@ -558,7 +579,7 @@ class LocalAnnotationScanner(
                     if (canonicalName !in scanResult.customScopeByCanonicalName) {
                         scanResult.customScopeByCanonicalName[canonicalName] = scope
                     }
-                    scanResult.customScopeByQualifiedName[qualifiedName] = scope
+                    customScopeByQualifiedName[qualifiedName] = scope
                     scopeBySymbol[symbol] = scope
                     return scope
                 }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalScanResult.kt
@@ -49,14 +49,6 @@ class LocalScanResult {
     val customScopeByCanonicalName = HashMap<String, Scope.Custom>()
 
     /**
-     * Represents custom scopes grouped by their FQN, which is intended for fast-lookup.
-     *
-     * This includes scopes that are registered via custom annotation (e.g. `@Session`) and
-     * scope dependencies (`@DependsOn(...)`). **Do not use this to query registered scopes!**
-     */
-    val customScopeByQualifiedName = HashMap<String, Scope.Custom>()
-
-    /**
      * Represents scope dependencies that are registered via `@DependsOn`.
      * - Key: The registered scope
      * - Value: Its dependency


### PR DESCRIPTION
### Summary

Collect contributed scopes and build direct scope dependency edges in the aggregator. This phase focuses on normalizing scope metadata, validating duplicate scope declarations, and preparing the data needed for later scope graph traversal.

### Implementation Details

- Normalize scope modeling by using `"singleton"` as the canonical name for `Scope.Singleton`.
- Move `customScopeByQualifiedName` out of `LocalScanResult` and keep it as a local cache inside `LocalAnnotationScanner`.
- Extend `ContributionScanner` to collect contributed scopes, merge them by canonical name, detect duplicate annotation-class declarations, and build direct scope dependency edges.
- Return collected scope metadata as part of `ContributionScanResult.Success` so later graph-building logic can traverse and validate the global scope graph.

Closes #126