### PR TITLE
fix(compiler): Ensure ContributionCodeGenerator generate all metadata under incremental/cached builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ kotlin.code.style=official
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableNativeIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
+ksp.incremental.log=true
 
 # Dokka settings
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
@@ -66,7 +66,7 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
             .addType(outputObject)
             .build()
         val outputStream = codeGenerator.createNewFile(
-            dependencies = Dependencies(aggregating = true),
+            dependencies = Dependencies.ALL_FILES,
             packageName = GENERATED_PACKAGE_NAME,
             fileName = fileName,
         )
@@ -187,12 +187,26 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
      * Returns sorted bindings by stable IDs, which includes:
      * - provided bindings + their dependencies
      * - requested bindings
+     *
+     * Bindings that are already provided will be prioritized.
      */
     private fun LocalScanResult.getSortedBindingsWithId(): Map<BindingDeclaration, Int> {
         val bindings = LinkedHashSet<BindingDeclaration>()
         bindings += providedBindings.values
-        providedBindings.values.forEach { it.dependencies?.let(bindings::addAll) }
-        bindings += requestedBindingsByClass.values.flatten()
+        for (providedBinding in providedBindings.values) {
+            providedBinding.dependencies?.forEach { dependency ->
+                if (dependency !in providedBindings) {
+                    bindings.add(dependency)
+                }
+            }
+        }
+        for (requestedBindings in requestedBindingsByClass.values) {
+            for (requestedBinding in requestedBindings) {
+                if (requestedBinding !in providedBindings) {
+                    bindings.add(requestedBinding)
+                }
+            }
+        }
         var nextId = 1
         return bindings.sortedWith(compareBy({ it.type }, { it.qualifier?.toString().orEmpty() }))
             .associateWith { nextId++ }


### PR DESCRIPTION
### Summary

Stabilize contributor metadata generation under incremental and cached builds, and reduce ambiguity in the contributed binding pool by prioritizing provided bindings as the source of truth.

### Implementation Details

- Switch contributor output generation to `Dependencies.ALL_FILES` so each generated `@Contribute` file is rebuilt from the full module state instead of a partial incremental view.
- Refine `getSortedBindingsWithId()` so provided bindings are collected first and dependencies or requested bindings are only added when they are not already provided.

Closes #128