### PR TITLE
feat(compiler): Provide ancestor lookup + cycle detection on scope graph

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
@@ -88,7 +88,7 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
                 add("type = %S,\n", binding.type)
                 add("qualifier = %S,\n", binding.qualifier?.encode().orEmpty())
                 if (binding is ProvidedBinding) {
-                    add("scope = %S,\n", binding.scope?.toString().orEmpty())
+                    add("scope = %S,\n", binding.scope?.canonicalName.orEmpty())
                     add("location = %S,\n", binding.location)
                     add("kind = %L,\n", binding.kind)
                     add("providerPackageName = %S,\n", binding.providerPackageName)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -20,6 +20,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.harrytmthy.stitch.compiler.provider.ScopeAncestorsProvider
 import com.harrytmthy.stitch.compiler.scanner.ContributionScanner
 import com.harrytmthy.stitch.compiler.scanner.LocalAnnotationScanner
 import com.harrytmthy.stitch.compiler.scanner.LocalScanResult
@@ -53,11 +54,12 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
                     .generate(moduleName, moduleKey, localScanResult)
             } else {
                 val logger = StitchErrorLogger(environment.logger)
-                ContributionScanner(resolver, logger, moduleKey, localScanResult).scan()
-                if (logger.hasError) {
+                val scanResult = ContributionScanner(resolver, logger, moduleKey, localScanResult)
+                    .scan()
+                if (scanResult == null) {
                     return emptyList()
                 }
-                // TODO: Add scope graph builder
+                ScopeAncestorsProvider(scanResult).get()
                 // TODO: Add binding graph builder
                 // TODO: Add codegen for InjectorScope's implementation
             }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
@@ -21,6 +21,12 @@ package com.harrytmthy.stitch.compiler.model
  */
 open class Binding(val type: String, val qualifier: Qualifier?) {
 
+    override fun toString(): String =
+        buildString {
+            append(type)
+            qualifier?.let(::append)
+        }
+
     override fun hashCode(): Int =
         if (qualifier != null) {
             type.hashCode() + (31 * qualifier.hashCode())
@@ -109,7 +115,7 @@ sealed class Scope {
 
         override val canonicalName: String = "singleton"
 
-        override fun toString(): String = canonicalName
+        override fun toString(): String = "Singleton"
 
         override fun hashCode(): Int = canonicalName.hashCode()
 

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/provider/ScopeAncestorsProvider.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/provider/ScopeAncestorsProvider.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler.provider
+
+import com.harrytmthy.stitch.compiler.fatalError
+import com.harrytmthy.stitch.compiler.model.Scope
+import com.harrytmthy.stitch.compiler.scanner.ContributionScanResult
+
+class ScopeAncestorsProvider(private val scanResult: ContributionScanResult) {
+
+    private val scopeAncestors = HashMap<Scope, LinkedHashSet<Scope>>()
+
+    fun get(): Map<Scope, Set<Scope>> {
+        for (scope in scanResult.customScopeByCanonicalName.values) {
+            collectAncestors(scope, scanResult.scopeDependencies)
+        }
+        return scopeAncestors
+    }
+
+    private fun collectAncestors(scope: Scope, scopeDependencies: Map<Scope, Scope>) {
+        if (scope in scopeAncestors) {
+            // Already visited
+            return
+        }
+        val ancestors = linkedSetOf(scope)
+        scopeAncestors[scope] = ancestors
+        val directAncestor = scopeDependencies[scope]
+        if (directAncestor == null || directAncestor == Scope.Singleton) {
+            ancestors.add(Scope.Singleton)
+            return
+        }
+        collectAncestors(directAncestor, scopeDependencies)
+        val directAncestorAncestors = scopeAncestors.getValue(directAncestor)
+        if (scope in directAncestorAncestors) {
+            val cyclePath = directAncestorAncestors.joinToString(" → ")
+            fatalError(
+                message = "A cycle is detected in scope graph: $scope → $cyclePath",
+                symbol = null,
+            )
+        }
+        ancestors.addAll(directAncestorAncestors)
+    }
+}

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanResult.kt
@@ -21,14 +21,9 @@ import com.harrytmthy.stitch.compiler.model.ProvidedBinding
 import com.harrytmthy.stitch.compiler.model.RequestedBinding
 import com.harrytmthy.stitch.compiler.model.Scope
 
-sealed class ContributionScanResult {
-
-    data object Error : ContributionScanResult()
-
-    data class Success(
-        val providedBindings: Map<Binding, ProvidedBinding>,
-        val requestedBindingsByModuleKey: Map<String, Map<String, List<RequestedBinding>>>,
-        val customScopeByCanonicalName: Map<String, Scope.Custom>,
-        val scopeDependencies: Map<Scope, Scope>,
-    ) : ContributionScanResult()
-}
+class ContributionScanResult(
+    val providedBindings: Map<Binding, ProvidedBinding>,
+    val requestedBindingsByModuleKey: Map<String, Map<String, List<RequestedBinding>>>,
+    val customScopeByCanonicalName: Map<String, Scope.Custom>,
+    val scopeDependencies: Map<Scope, Scope>,
+)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
@@ -38,7 +38,7 @@ class ContributionScanner(
 
     @OptIn(KspExperimental::class)
     @Suppress("UNCHECKED_CAST")
-    fun scan(): ContributionScanResult {
+    fun scan(): ContributionScanResult? {
         // Step 1: Collect all bindings and scopes from the aggregator
         val providedBindings = HashMap(scanResult.providedBindings)
         val requestedBindingsByModuleKey = HashMap<String, Map<String, List<RequestedBinding>>>()
@@ -158,7 +158,7 @@ class ContributionScanner(
             }
         }
         if (logger.hasError) {
-            return ContributionScanResult.Error
+            return null
         }
 
         // Step 3: Ensure all requested bindings are actually provided
@@ -172,7 +172,7 @@ class ContributionScanner(
             }
         }
         if (logger.hasError) {
-            return ContributionScanResult.Error
+            return null
         }
 
         // Step 4: Build binding edges
@@ -188,7 +188,7 @@ class ContributionScanner(
             }
         }
 
-        return ContributionScanResult.Success(
+        return ContributionScanResult(
             providedBindings,
             requestedBindingsByModuleKey,
             customScopeByCanonicalName,

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
@@ -194,6 +194,9 @@ class LocalAnnotationScanner(
             val annotation = symbol.annotations.find(DEPENDS_ON)
             val dependency = annotation.arguments[0].value as KSType
             val qualifiedName = dependency.declaration.qualifiedName(symbol)
+            if (scope is Scope.Custom && scope.qualifiedName == qualifiedName) {
+                fatalError("Scope '$scope' depends on itself", symbol)
+            }
             customScopeByQualifiedName[qualifiedName]?.let { dependency ->
                 scanResult.scopeDependencies[scope] = dependency
                 continue


### PR DESCRIPTION
### Summary

Add scope graph traversal on the aggregator side to detect cycles and provide ancestor lookup for later binding graph validation.

### Implementation Details

- Normalize generated contributed binding scopes to use canonical scope names instead of `toString()`.
- Add `ScopeAncestorsProvider` to traverse the collected scope graph and build ancestor lookup data.
- Detect scope cycles during traversal and report a clear cycle path when found.
- Simplify `ContributionScanResult` into a single success-shaped result object, with `ContributionScanner.scan()` returning `null` on aggregator-side error.
- Add a local self-dependency guard in `LocalAnnotationScanner` for `@DependsOn(...)`.

Closes #130