### PR TITLE
feat(compiler): Provide scope depth metadata

### DIFF
--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
@@ -22,10 +22,10 @@ import com.harrytmthy.stitch.annotations.Contribute
 import com.harrytmthy.stitch.compiler.StitchSymbolProcessor.Companion.GENERATED_PACKAGE_NAME
 import com.harrytmthy.stitch.compiler.consts.BindingKind
 import com.harrytmthy.stitch.compiler.model.BindingDeclaration
+import com.harrytmthy.stitch.compiler.model.LocalScanResult
 import com.harrytmthy.stitch.compiler.model.ProvidedBinding
 import com.harrytmthy.stitch.compiler.model.RequestedBinding
 import com.harrytmthy.stitch.compiler.model.Scope
-import com.harrytmthy.stitch.compiler.scanner.LocalScanResult
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -20,10 +20,10 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
-import com.harrytmthy.stitch.compiler.provider.ScopeAncestorsProvider
+import com.harrytmthy.stitch.compiler.model.LocalScanResult
+import com.harrytmthy.stitch.compiler.provider.ScopeMetadataProvider
 import com.harrytmthy.stitch.compiler.scanner.ContributionScanner
 import com.harrytmthy.stitch.compiler.scanner.LocalAnnotationScanner
-import com.harrytmthy.stitch.compiler.scanner.LocalScanResult
 import com.harrytmthy.stitch.compiler.utils.StitchErrorLogger
 import java.security.MessageDigest
 
@@ -59,7 +59,7 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
                 if (scanResult == null) {
                     return emptyList()
                 }
-                ScopeAncestorsProvider(scanResult).get()
+                ScopeMetadataProvider(scanResult).get()
                 // TODO: Add binding graph builder
                 // TODO: Add codegen for InjectorScope's implementation
             }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/ContributionScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/ContributionScanResult.kt
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-package com.harrytmthy.stitch.compiler.scanner
-
-import com.harrytmthy.stitch.compiler.model.Binding
-import com.harrytmthy.stitch.compiler.model.ProvidedBinding
-import com.harrytmthy.stitch.compiler.model.RequestedBinding
-import com.harrytmthy.stitch.compiler.model.Scope
+package com.harrytmthy.stitch.compiler.model
 
 class ContributionScanResult(
     val providedBindings: Map<Binding, ProvidedBinding>,

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/LocalScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/LocalScanResult.kt
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-package com.harrytmthy.stitch.compiler.scanner
-
-import com.harrytmthy.stitch.compiler.model.BindingPool
-import com.harrytmthy.stitch.compiler.model.ProvidedBinding
-import com.harrytmthy.stitch.compiler.model.RequestedBinding
-import com.harrytmthy.stitch.compiler.model.Scope
+package com.harrytmthy.stitch.compiler.model
 
 /**
  * Stores useful local data to build dependency graph and generate code.

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/ScopeMetadata.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/ScopeMetadata.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler.model
+
+class ScopeMetadata(val ancestors: Set<Scope>, var depth: Int = 0)

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/provider/ScopeMetadataProvider.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/provider/ScopeMetadataProvider.kt
@@ -17,34 +17,40 @@
 package com.harrytmthy.stitch.compiler.provider
 
 import com.harrytmthy.stitch.compiler.fatalError
+import com.harrytmthy.stitch.compiler.model.ContributionScanResult
 import com.harrytmthy.stitch.compiler.model.Scope
-import com.harrytmthy.stitch.compiler.scanner.ContributionScanResult
+import com.harrytmthy.stitch.compiler.model.ScopeMetadata
 
-class ScopeAncestorsProvider(private val scanResult: ContributionScanResult) {
+class ScopeMetadataProvider(private val scanResult: ContributionScanResult) {
 
-    private val scopeAncestors = HashMap<Scope, LinkedHashSet<Scope>>()
-
-    fun get(): Map<Scope, Set<Scope>> {
+    fun get(): Map<Scope, ScopeMetadata> {
+        val scopeMetadata = HashMap<Scope, ScopeMetadata>()
         for (scope in scanResult.customScopeByCanonicalName.values) {
-            collectAncestors(scope, scanResult.scopeDependencies)
+            collectMetadata(scope, scanResult.scopeDependencies, scopeMetadata)
         }
-        return scopeAncestors
+        return scopeMetadata
     }
 
-    private fun collectAncestors(scope: Scope, scopeDependencies: Map<Scope, Scope>) {
-        if (scope in scopeAncestors) {
+    private fun collectMetadata(
+        scope: Scope,
+        scopeDependencies: Map<Scope, Scope>,
+        scopeMetadata: HashMap<Scope, ScopeMetadata>,
+    ) {
+        if (scope in scopeMetadata) {
             // Already visited
             return
         }
         val ancestors = linkedSetOf(scope)
-        scopeAncestors[scope] = ancestors
+        scopeMetadata[scope] = ScopeMetadata(ancestors)
         val directAncestor = scopeDependencies[scope]
         if (directAncestor == null || directAncestor == Scope.Singleton) {
+            // Direct child of Singleton
             ancestors.add(Scope.Singleton)
+            scopeMetadata[scope] = ScopeMetadata(ancestors, depth = 2)
             return
         }
-        collectAncestors(directAncestor, scopeDependencies)
-        val directAncestorAncestors = scopeAncestors.getValue(directAncestor)
+        collectMetadata(directAncestor, scopeDependencies, scopeMetadata)
+        val directAncestorAncestors = scopeMetadata.getValue(directAncestor).ancestors
         if (scope in directAncestorAncestors) {
             val cyclePath = directAncestorAncestors.joinToString(" → ")
             fatalError(
@@ -53,5 +59,7 @@ class ScopeAncestorsProvider(private val scanResult: ContributionScanResult) {
             )
         }
         ancestors.addAll(directAncestorAncestors)
+        val depth = scopeMetadata.getValue(directAncestor).depth + 1
+        scopeMetadata.getValue(scope).depth = depth
     }
 }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
@@ -23,6 +23,8 @@ import com.harrytmthy.stitch.annotations.Contribute
 import com.harrytmthy.stitch.compiler.StitchSymbolProcessor.Companion.GENERATED_PACKAGE_NAME
 import com.harrytmthy.stitch.compiler.consts.BindingKind
 import com.harrytmthy.stitch.compiler.model.BindingDeclaration
+import com.harrytmthy.stitch.compiler.model.ContributionScanResult
+import com.harrytmthy.stitch.compiler.model.LocalScanResult
 import com.harrytmthy.stitch.compiler.model.ProvidedBinding
 import com.harrytmthy.stitch.compiler.model.Qualifier
 import com.harrytmthy.stitch.compiler.model.RequestedBinding

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
@@ -30,6 +30,7 @@ import com.harrytmthy.stitch.compiler.consts.BindingKind
 import com.harrytmthy.stitch.compiler.fatalError
 import com.harrytmthy.stitch.compiler.model.BindingDeclaration
 import com.harrytmthy.stitch.compiler.model.BindingPool
+import com.harrytmthy.stitch.compiler.model.LocalScanResult
 import com.harrytmthy.stitch.compiler.model.ProvidedBinding
 import com.harrytmthy.stitch.compiler.model.Qualifier
 import com.harrytmthy.stitch.compiler.model.RequestedBinding


### PR DESCRIPTION
### Summary

This PR upgrades the scope traversal result from ancestor lookup alone into richer scope metadata, including depth information for each registered scope.

It also renames the provider to `ScopeMetadataProvider` and moves both contribution/local scan result models into the `model` package for better ownership and clarity.

### Implementation Details

The scope traversal now returns `ScopeMetadata`, which contains:
- the full ancestor set of each scope
- the inferred depth of each scope in the hierarchy

Depth is computed recursively from the current scope's direct ancestor, so traversal can still start from any discovered scope without requiring a pre-sorted root-first or leaf-first order.

Cycle detection remains part of the same traversal and still reports the full offending path when a scope loop is found.

Additionally:
- `ContributionScanResult` and `LocalScanResult` were moved to `model`
- `ScopeAncestorsProvider` was renamed to `ScopeMetadataProvider`

Closes #133