### PR TITLE
feat(compiler): Add BindingGraphValidator

### DIFF
--- a/stitch-compiler/build.gradle.kts
+++ b/stitch-compiler/build.gradle.kts
@@ -26,8 +26,9 @@ dependencies {
     implementation(libs.kotlinpoet)
     implementation(libs.kotlinpoet.ksp)
     implementation(libs.ksp.api)
+    testImplementation(libs.kotlin.test)
 
-    // Support for Dagger annotations
+    // Support for javax annotations
     compileOnly(libs.javax.inject)
 }
 

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/BindingGraphValidator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/BindingGraphValidator.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+import com.harrytmthy.stitch.compiler.model.BindingDeclaration
+import com.harrytmthy.stitch.compiler.model.ContributionScanResult
+import com.harrytmthy.stitch.compiler.model.ProvidedBinding
+import com.harrytmthy.stitch.compiler.model.Scope
+
+class BindingGraphValidator(
+    private val scanResult: ContributionScanResult,
+    private val scopeAncestors: Map<Scope, Set<Scope>>,
+) {
+
+    fun validate(): Map<ProvidedBinding, ResolvedBinding> {
+        val visiting = LinkedHashSet<ProvidedBinding>()
+        val resolvedByBinding = HashMap<ProvidedBinding, ResolvedBinding>()
+        for (binding in scanResult.providedBindings.values) {
+            resolve(binding, visiting, resolvedByBinding)
+        }
+        return resolvedByBinding
+    }
+
+    private fun resolve(
+        binding: ProvidedBinding,
+        visiting: LinkedHashSet<ProvidedBinding>,
+        resolvedByBinding: HashMap<ProvidedBinding, ResolvedBinding>,
+    ): ResolvedBinding {
+        resolvedByBinding[binding]?.let { return it }
+        if (!visiting.add(binding)) {
+            cycleError(binding, visiting)
+        }
+        try {
+            val dependencyResults = ArrayList<Pair<ProvidedBinding, ResolvedBinding>>(
+                binding.dependencies?.size ?: 0,
+            )
+            binding.dependencies?.forEach { dependencyDeclaration ->
+                val dependency = scanResult.providedBindings[dependencyDeclaration]
+                    ?: missingBindingError(dependencyDeclaration)
+                val resolvedDependency = resolve(dependency, visiting, resolvedByBinding)
+                dependencyResults += dependency to resolvedDependency
+            }
+            val result = when (val declaredScope = binding.scope) {
+                null -> resolveUnscoped(binding, dependencyResults)
+                else -> resolveScoped(binding, declaredScope, dependencyResults)
+            }
+            resolvedByBinding[binding] = result
+            return result
+        } finally {
+            visiting.remove(binding)
+        }
+    }
+
+    private fun resolveScoped(
+        binding: ProvidedBinding,
+        declaredScope: Scope,
+        dependencyResults: List<Pair<ProvidedBinding, ResolvedBinding>>,
+    ): ResolvedBinding {
+        val ancestors = scopeAncestors.getValue(declaredScope)
+        val scopedOwnersInClosure = LinkedHashSet<ScopedOwner>()
+        for ((dependency, resolvedDependency) in dependencyResults) {
+            if (resolvedDependency.owningScope !in ancestors) {
+                wrongScopeError(
+                    binding = binding,
+                    dependency = dependency,
+                    dependencyOwningScope = resolvedDependency.owningScope,
+                    allowedScopes = ancestors,
+                )
+            }
+            scopedOwnersInClosure += resolvedDependency.scopedOwnersInClosure
+        }
+        if (declaredScope is Scope.Custom) {
+            scopedOwnersInClosure += ScopedOwner(binding, declaredScope)
+        }
+        return ResolvedBinding(
+            owningScope = declaredScope,
+            scopedOwnersInClosure = scopedOwnersInClosure,
+        )
+    }
+
+    private fun resolveUnscoped(
+        binding: ProvidedBinding,
+        dependencyResults: List<Pair<ProvidedBinding, ResolvedBinding>>,
+    ): ResolvedBinding {
+        val scopedOwnersInClosure = LinkedHashSet<ScopedOwner>()
+        var deepestOwner: ScopedOwner? = null
+        for ((dependency, resolvedDependency) in dependencyResults) {
+            scopedOwnersInClosure += resolvedDependency.scopedOwnersInClosure
+            val owningScope = resolvedDependency.owningScope
+            if (owningScope is Scope.Custom) {
+                val candidate = ScopedOwner(dependency, owningScope)
+                if (deepestOwner == null || owningScope.depth > deepestOwner.scope.depth) {
+                    deepestOwner = candidate
+                }
+            }
+        }
+        val deepestScope = deepestOwner?.scope
+        if (deepestScope != null) {
+            val ancestors = scopeAncestors.getValue(deepestScope)
+            for (scopedOwner in scopedOwnersInClosure) {
+                if (scopedOwner.scope !in ancestors) {
+                    incompatibleUnscopedClosureError(
+                        binding = binding,
+                        deepestOwner = deepestOwner,
+                        conflictingOwner = scopedOwner,
+                        allowedScopes = ancestors,
+                    )
+                }
+            }
+        }
+        return ResolvedBinding(
+            owningScope = deepestScope ?: Scope.Singleton,
+            scopedOwnersInClosure = scopedOwnersInClosure,
+        )
+    }
+
+    private fun cycleError(
+        binding: ProvidedBinding,
+        visiting: LinkedHashSet<ProvidedBinding>,
+    ): Nothing {
+        val cycle = buildList {
+            var include = false
+            for (visited in visiting) {
+                if (visited == binding) {
+                    include = true
+                }
+                if (include) {
+                    add(visited)
+                }
+            }
+            add(binding)
+        }
+        val path = cycle.joinToString(" → ")
+        fatalError(
+            message = "A cycle is detected in the dependency graph:\n$path",
+            symbol = null,
+        )
+    }
+
+    private fun wrongScopeError(
+        binding: ProvidedBinding,
+        dependency: ProvidedBinding,
+        dependencyOwningScope: Scope,
+        allowedScopes: Set<Scope>,
+    ): Nothing =
+        fatalError(
+            message = buildString {
+                append("Binding $binding is declared in ${binding.scope} (${binding.location}), ")
+                append("but depends on $dependency which resolves to $dependencyOwningScope ")
+                append("(${dependency.location}). Allowed scopes: ${allowedScopes.joinToString()}")
+            },
+            symbol = null,
+        )
+
+    private fun missingBindingError(binding: BindingDeclaration): Nothing =
+        fatalError("Binding $binding is requested but never provided", symbol = null)
+
+    private fun incompatibleUnscopedClosureError(
+        binding: ProvidedBinding,
+        deepestOwner: ScopedOwner,
+        conflictingOwner: ScopedOwner,
+        allowedScopes: Set<Scope>,
+    ): Nothing =
+        fatalError(
+            message = buildString {
+                append("Unscoped binding $binding resolves into ${deepestOwner.scope} because of")
+                append(" ${deepestOwner.binding}, but also depends on ${conflictingOwner.binding}")
+                append(" which resolves into ${conflictingOwner.scope}")
+                append(" (${conflictingOwner.binding.location}). ")
+                append("Allowed scopes from ${deepestOwner.scope}: ${allowedScopes.joinToString()}")
+            },
+            symbol = null,
+        )
+
+    data class ResolvedBinding(
+        val owningScope: Scope,
+        val scopedOwnersInClosure: Set<ScopedOwner>,
+    )
+
+    data class ScopedOwner(
+        val binding: ProvidedBinding,
+        val scope: Scope.Custom,
+    )
+}

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -59,7 +59,8 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
                 if (scanResult == null) {
                     return emptyList()
                 }
-                ScopeAncestorsProvider(scanResult).get()
+                val scopeAncestors = ScopeAncestorsProvider(scanResult).get()
+                BindingGraphValidator(scanResult, scopeAncestors).validate()
                 // TODO: Add binding graph builder
                 // TODO: Add codegen for InjectorScope's implementation
             }

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
@@ -24,7 +24,7 @@ open class Binding(val type: String, val qualifier: Qualifier?) {
     override fun toString(): String =
         buildString {
             append(type)
-            qualifier?.let(::append)
+            qualifier?.let { append(" (qualifier: $it)") }
         }
 
     override fun hashCode(): Int =

--- a/stitch-compiler/src/test/kotlin/com/harrytmthy/stitch/compiler/BindingGraphValidatorTest.kt
+++ b/stitch-compiler/src/test/kotlin/com/harrytmthy/stitch/compiler/BindingGraphValidatorTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2026 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.stitch.compiler
+
+import com.harrytmthy.stitch.compiler.consts.BindingKind
+import com.harrytmthy.stitch.compiler.model.Binding
+import com.harrytmthy.stitch.compiler.model.ContributionScanResult
+import com.harrytmthy.stitch.compiler.model.ProvidedBinding
+import com.harrytmthy.stitch.compiler.model.Qualifier
+import com.harrytmthy.stitch.compiler.model.Scope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BindingGraphValidatorTest {
+
+    @Test
+    fun validate_shouldInferSingleton_whenUnscopedClosureHasNoCustomScope() {
+        val logger = provided("Logger", scope = Scope.Singleton)
+        val config = provided("Config", dependencies = listOf(logger))
+        val presenter = provided("Presenter", dependencies = listOf(config))
+
+        val validator = BindingGraphValidator(
+            scanResult = scanResult(logger, config, presenter),
+            scopeAncestors = scopeAncestors(),
+        )
+
+        val resolved = validator.validate()
+
+        assertEquals(Scope.Singleton, resolved.getValue(config).owningScope)
+        assertEquals(Scope.Singleton, resolved.getValue(presenter).owningScope)
+    }
+
+    @Test
+    fun validate_shouldInferDeepestCustomScope_forUnscopedBinding() {
+        val activity = customScope("activity", depth = 2)
+        val repository = provided("Repository", scope = activity)
+        val config = provided("Config", dependencies = listOf(repository))
+        val presenter = provided("Presenter", dependencies = listOf(config))
+
+        val validator = BindingGraphValidator(
+            scanResult = scanResult(repository, config, presenter),
+            scopeAncestors = scopeAncestors(activity),
+        )
+
+        val resolved = validator.validate()
+
+        assertEquals(activity, resolved.getValue(config).owningScope)
+        assertEquals(activity, resolved.getValue(presenter).owningScope)
+    }
+
+    @Test
+    fun validate_shouldFail_whenUnscopedBindingDependsOnMultipleBranches() {
+        val activity = customScope("activity", depth = 2)
+        val fragment = customScope("fragment", depth = 3)
+        val service = customScope("service", depth = 2)
+
+        val c = provided("C", scope = activity)
+        val d = provided("D", scope = fragment)
+        val e = provided("E", scope = service)
+
+        val a = provided("A", dependencies = listOf(c))
+        val b = provided("B", dependencies = listOf(a, d, e))
+
+        val validator = BindingGraphValidator(
+            scanResult = scanResult(c, d, e, a, b),
+            scopeAncestors = scopeAncestors(activity, fragment, service),
+        )
+
+        assertFailsWith<StitchProcessingException> {
+            validator.validate()
+        }
+    }
+
+    @Test
+    fun validate_shouldFail_whenScopedBindingDependsOnDescendantScope() {
+        val activity = customScope("activity", depth = 2)
+        val fragment = customScope("fragment", depth = 3)
+
+        val child = provided("Child", scope = fragment)
+        val parent = provided("Parent", scope = activity, dependencies = listOf(child))
+
+        val validator = BindingGraphValidator(
+            scanResult = scanResult(child, parent),
+            scopeAncestors = scopeAncestors(activity, fragment),
+        )
+
+        assertFailsWith<StitchProcessingException> {
+            validator.validate()
+        }
+    }
+
+    @Test
+    fun validate_shouldFail_whenCycleExists() {
+        val a = provided("A")
+        val b = provided("B")
+
+        a.dependencies = arrayListOf(b)
+        b.dependencies = arrayListOf(a)
+
+        val validator = BindingGraphValidator(
+            scanResult = scanResult(a, b),
+            scopeAncestors = scopeAncestors(),
+        )
+
+        assertFailsWith<StitchProcessingException> {
+            validator.validate()
+        }
+    }
+
+    @Test
+    fun validate_shouldNotTreatResolvedNodeAsCycle() {
+        val loggerImpl = provided("LoggerImpl", scope = Scope.Singleton)
+        val logger = provided("Logger", dependencies = listOf(loggerImpl))
+        val baseUrl = provided("String", qualifier = Qualifier.Named("baseUrl"), scope = Scope.Singleton)
+        val apiService = provided("ApiService", dependencies = listOf(logger, baseUrl))
+        val userRepositoryImpl = provided("UserRepositoryImpl", dependencies = listOf(logger, apiService))
+        val userReader = provided("UserReader", dependencies = listOf(userRepositoryImpl))
+
+        val validator = BindingGraphValidator(
+            scanResult = scanResult(loggerImpl, logger, baseUrl, apiService, userRepositoryImpl, userReader),
+            scopeAncestors = scopeAncestors(),
+        )
+
+        validator.validate() // should not throw
+    }
+
+    private fun scanResult(vararg bindings: ProvidedBinding): ContributionScanResult {
+        val providedBindings = LinkedHashMap<Binding, ProvidedBinding>()
+        bindings.forEach { providedBindings[it] = it }
+        return ContributionScanResult(
+            providedBindings = providedBindings,
+            requestedBindingsByModuleKey = emptyMap(),
+            customScopeByCanonicalName = bindings.mapNotNull { it.scope as? Scope.Custom }
+                .associateBy { it.canonicalName },
+            scopeDependencies = emptyMap(),
+        )
+    }
+
+    private fun provided(
+        type: String,
+        qualifier: Qualifier? = null,
+        scope: Scope? = null,
+        dependencies: List<ProvidedBinding> = emptyList(),
+    ): ProvidedBinding =
+        ProvidedBinding(
+            type = type,
+            qualifier = qualifier,
+            scope = scope,
+            location = "$type.kt:1",
+            kind = BindingKind.PROVIDED_IN_CONSTRUCTOR,
+            moduleKey = "TEST",
+        ).apply {
+            this.dependencies = ArrayList(dependencies)
+        }
+
+    private fun customScope(name: String, depth: Int): Scope.Custom =
+        Scope.Custom(
+            canonicalName = name,
+            qualifiedName = "test.$name",
+            location = "$name.kt:1",
+        ).also { it.depth = depth }
+
+    private fun scopeAncestors(
+        vararg scopes: Scope.Custom,
+    ): Map<Scope, Set<Scope>> {
+        val map = LinkedHashMap<Scope, Set<Scope>>()
+        map[Scope.Singleton] = setOf(Scope.Singleton)
+
+        scopes.forEach { scope ->
+            val ancestors = linkedSetOf(scope, Scope.Singleton)
+            when (scope.canonicalName) {
+                "fragment" -> {
+                    val activity = scopes.first { it.canonicalName == "activity" }
+                    ancestors.add(activity)
+                }
+            }
+            map[scope] = ancestors
+        }
+        return map
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds binding graph validation for the aggregator, covering both dependency cycle detection and scope compatibility checks.

### Implementation Details

A new `BindingGraphValidator` now traverses provided bindings after contribution scanning and scope ancestor preparation.

The validator:
- detects dependency cycles with DFS
- validates scoped bindings against allowed ancestor scopes
- resolves unscoped bindings to their effective owning scope based on the deepest valid custom scope in their transitive closure
- reports incompatible unscoped closures when dependencies come from different scope branches

The traversal also memoizes resolved bindings so the result can be reused later by code generation, while `try/finally` ensures the active DFS stack stays clean even when resolution fails.

Unit tests were added to cover the critical graph-validation cases, including:
- singleton inference for fully unscoped closures
- deepest-scope inference for unscoped bindings
- invalid cross-branch unscoped closures
- invalid descendant-scope dependencies
- cycle detection
- revisiting an already resolved node without falsely reporting a cycle

Closes #132