### PR TITLE
refactor(compiler): Remove moduleKey and flatten requested bindings in ContributionScanner

### DIFF
--- a/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
+++ b/stitch-annotations/src/main/kotlin/com/harrytmthy/stitch/annotations/Contribute.kt
@@ -19,7 +19,6 @@ package com.harrytmthy.stitch.annotations
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
 annotation class Contribute(
-    val moduleKey: String,
     val bindings: Array<ContributedBinding>,
     val requesters: Array<BindingRequester>,
     val scopes: Array<RegisteredScope>,

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/ContributionCodeGenerator.kt
@@ -39,9 +39,8 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
         val sortedBindings = localScanResult.getSortedBindingsWithId()
         val contributedBindings = buildContributedBindings(sortedBindings)
         val contributeAnnotation = AnnotationSpec.builder(Contribute::class).apply {
-            addMember("moduleKey = %S", moduleKey)
             addMember("bindings = %L", contributedBindings)
-            if (localScanResult.requestedBindingsByClass.isNotEmpty()) {
+            if (localScanResult.requestedBindings.isNotEmpty()) {
                 val sortedRequestedBindings = localScanResult.getSortedRequestedBindings()
                 val requesters = buildBindingRequesters(sortedBindings, sortedRequestedBindings)
                 addMember("requesters = %L", requesters)
@@ -200,7 +199,7 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
                 }
             }
         }
-        for (requestedBindings in requestedBindingsByClass.values) {
+        for (requestedBindings in requestedBindings.values) {
             for (requestedBinding in requestedBindings) {
                 if (requestedBinding !in providedBindings) {
                     bindings.add(requestedBinding)
@@ -216,7 +215,7 @@ class ContributionCodeGenerator(private val codeGenerator: CodeGenerator) {
      * Produces stable ordering for Gradle cache hits.
      */
     private fun LocalScanResult.getSortedRequestedBindings(): Map<String, List<RequestedBinding>> =
-        requestedBindingsByClass.toSortedMap() // sort by requester's FQN
+        requestedBindings.toSortedMap() // sort by requester's FQN
             .mapValues { (_, fields) ->
                 val comparator = compareBy<RequestedBinding>(
                     { it.fieldName },

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/StitchSymbolProcessor.kt
@@ -48,13 +48,13 @@ class StitchSymbolProcessor(private val environment: SymbolProcessorEnvironment)
             val moduleName = getOption("stitch.moduleName")
             val moduleKey = moduleName.toModuleKey()
             val localScanResult = LocalScanResult()
-            LocalAnnotationScanner(resolver, moduleKey, localScanResult).scan()
+            LocalAnnotationScanner(resolver, localScanResult).scan()
             if (!localScanResult.isAggregator) {
                 ContributionCodeGenerator(environment.codeGenerator)
                     .generate(moduleName, moduleKey, localScanResult)
             } else {
                 val logger = StitchErrorLogger(environment.logger)
-                val scanResult = ContributionScanner(resolver, logger, moduleKey, localScanResult)
+                val scanResult = ContributionScanner(resolver, logger, localScanResult)
                     .scan()
                 if (scanResult == null) {
                     return emptyList()

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/ContributionScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/ContributionScanResult.kt
@@ -18,7 +18,7 @@ package com.harrytmthy.stitch.compiler.model
 
 class ContributionScanResult(
     val providedBindings: Map<Binding, ProvidedBinding>,
-    val requestedBindingsByModuleKey: Map<String, Map<String, List<RequestedBinding>>>,
+    val requestedBindings: Map<String, List<RequestedBinding>>,
     val customScopeByCanonicalName: Map<String, Scope.Custom>,
     val scopeDependencies: Map<Scope, Scope>,
 )

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/LocalScanResult.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/LocalScanResult.kt
@@ -33,10 +33,10 @@ class LocalScanResult {
     val providedBindings = BindingPool<ProvidedBinding>()
 
     /**
-     * Represents bindings that are requested via field injections. This map collects the
-     * required data to generate DCL instances + `inject(target: T)`.
+     * Represents bindings that are requested via field injections, grouped by requester's FQN.
+     * This map collects the required data to generate DCL instances + `inject(target: T)`.
      */
-    val requestedBindingsByClass = HashMap<String, ArrayList<RequestedBinding>>()
+    val requestedBindings = HashMap<String, ArrayList<RequestedBinding>>()
 
     /**
      * Represents locally registered custom scopes.

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/model/Models.kt
@@ -62,7 +62,6 @@ class ProvidedBinding(
     val providerPackageName: String = "",
     val providerFunctionName: String = "",
     val providerClassName: String = "",
-    val moduleKey: String = "", // Only used by the aggregator
 ) : BindingDeclaration(type, qualifier, location) {
 
     var dependencies: ArrayList<BindingDeclaration>? = null

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/ContributionScanner.kt
@@ -34,7 +34,6 @@ import com.harrytmthy.stitch.compiler.utils.StitchErrorLogger
 class ContributionScanner(
     private val resolver: Resolver,
     private val logger: StitchErrorLogger,
-    private val moduleKey: String,
     private val scanResult: LocalScanResult,
 ) {
 
@@ -43,10 +42,9 @@ class ContributionScanner(
     fun scan(): ContributionScanResult? {
         // Step 1: Collect all bindings and scopes from the aggregator
         val providedBindings = HashMap(scanResult.providedBindings)
-        val requestedBindingsByModuleKey = HashMap<String, Map<String, List<RequestedBinding>>>()
-        requestedBindingsByModuleKey[moduleKey] = HashMap(scanResult.requestedBindingsByClass)
-        val customScopeByCanonicalName = HashMap<String, Scope.Custom>(scanResult.customScopeByCanonicalName)
-        val scopeDependencies = HashMap<Scope, Scope>(scanResult.scopeDependencies)
+        val requestedBindings = HashMap(scanResult.requestedBindings)
+        val customScopeByCanonicalName = HashMap(scanResult.customScopeByCanonicalName)
+        val scopeDependencies = HashMap(scanResult.scopeDependencies)
 
         // Step 2: Collect all bindings and scopes from the contributors
         val contributedBindings = ArrayList<BindingDeclaration>()
@@ -55,10 +53,9 @@ class ContributionScanner(
             val annotation = declaration.annotations
                 .find { it.shortName.asString() == Contribute::class.simpleName }
                 ?: continue
-            val moduleKey = annotation.arguments[0].value as String
-            val bindingAnnotations = annotation.arguments[1].value as List<KSAnnotation>
-            val requesterAnnotations = annotation.arguments[2].value as List<KSAnnotation>
-            val scopeAnnotations = annotation.arguments[3].value as List<KSAnnotation>
+            val bindingAnnotations = annotation.arguments[0].value as List<KSAnnotation>
+            val requesterAnnotations = annotation.arguments[1].value as List<KSAnnotation>
+            val scopeAnnotations = annotation.arguments[2].value as List<KSAnnotation>
 
             // Step 2.1: Collect all provided + requested bindings from the contributors
             val lastBindingIndex = contributedBindings.lastIndex
@@ -92,18 +89,18 @@ class ContributionScanner(
                         providerPackageName = providerPackageName,
                         providerFunctionName = providerFunctionName,
                         providerClassName = providerClassName,
-                        moduleKey = moduleKey,
                     )
                     providedBindings[binding] = providedBinding
                 }
             }
 
-            // Step 2.2: Collect all requesters, grouped by moduleKey
-            val requestedBindingsByRequester = HashMap<String, List<RequestedBinding>>()
+            // Step 2.2: Collect all requested bindings, grouped by requester's FQN
             for (requesterAnnotation in requesterAnnotations) {
                 val requesterQualifiedName = requesterAnnotation.arguments[0].value as String
                 val fields = requesterAnnotation.arguments[1].value as List<KSAnnotation>
-                val requestedBindings = ArrayList<RequestedBinding>(fields.size)
+                val requested = requestedBindings.getOrPut(requesterQualifiedName) {
+                    ArrayList(fields.size)
+                }
                 for (field in fields) {
                     val bindingId = field.arguments[0].value as Int
                     val fieldName = field.arguments[1].value as String
@@ -114,11 +111,9 @@ class ContributionScanner(
                         location = binding.location,
                         fieldName = fieldName,
                     )
-                    requestedBindings.add(requestedBinding)
-                    requestedBindingsByRequester[requesterQualifiedName] = requestedBindings
+                    requested.add(requestedBinding)
                 }
             }
-            requestedBindingsByModuleKey[moduleKey] = requestedBindingsByRequester
 
             // Step 2.3: Collect all scopes
             val localScopes = ArrayList<Scope.Custom>(scopeAnnotations.size)
@@ -164,12 +159,10 @@ class ContributionScanner(
         }
 
         // Step 3: Ensure all requested bindings are actually provided
-        for (requestedBindingsByRequester in requestedBindingsByModuleKey.values) {
-            for (requestedBindings in requestedBindingsByRequester.values) {
-                for (requestedBinding in requestedBindings) {
-                    if (requestedBinding !in providedBindings) {
-                        missingBindingError(requestedBinding)
-                    }
+        for (requested in requestedBindings.values) {
+            for (requestedBinding in requested) {
+                if (requestedBinding !in providedBindings) {
+                    missingBindingError(requestedBinding)
                 }
             }
         }
@@ -192,7 +185,7 @@ class ContributionScanner(
 
         return ContributionScanResult(
             providedBindings,
-            requestedBindingsByModuleKey,
+            requestedBindings,
             customScopeByCanonicalName,
             scopeDependencies,
         )

--- a/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
+++ b/stitch-compiler/src/main/kotlin/com/harrytmthy/stitch/compiler/scanner/LocalAnnotationScanner.kt
@@ -42,7 +42,6 @@ import com.harrytmthy.stitch.compiler.utils.qualifiedName
 
 class LocalAnnotationScanner(
     private val resolver: Resolver,
-    private val moduleKey: String,
     private val scanResult: LocalScanResult,
 ) {
 
@@ -316,7 +315,6 @@ class LocalAnnotationScanner(
                 providerPackageName = symbol.packageName.asString(),
                 providerFunctionName = symbol.simpleName.asString(),
                 providerClassName = parentDeclaration?.simpleName?.asString().orEmpty(),
-                moduleKey = moduleKey,
             )
 
             // ProvidedBinding is keyed only by type + qualifier, allowing `providedBindings`
@@ -375,7 +373,6 @@ class LocalAnnotationScanner(
             scope = scope,
             location = location,
             kind = BindingKind.PROVIDED_IN_CONSTRUCTOR,
-            moduleKey = moduleKey,
         )
 
         // ProvidedBinding is keyed only by type + qualifier, allowing `providedBindings`
@@ -409,7 +406,7 @@ class LocalAnnotationScanner(
         val fieldName = symbol.simpleName.asString()
         val binding = RequestedBinding(type, qualifier, location, fieldName)
         val parentQualifiedName = symbol.parentDeclaration!!.qualifiedName!!.asString()
-        val bindings = scanResult.requestedBindingsByClass.getOrPut(parentQualifiedName) { ArrayList() }
+        val bindings = scanResult.requestedBindings.getOrPut(parentQualifiedName) { ArrayList() }
         bindings.add(binding)
     }
 
@@ -551,7 +548,6 @@ class LocalAnnotationScanner(
             scope = null,
             location = location,
             kind = BindingKind.PROVIDED_ALIAS,
-            moduleKey = moduleKey,
         )
         providedAliases[alias]?.let { existingBinding ->
             duplicateBindingError(existingBinding, symbol)

--- a/stitch-compiler/src/test/kotlin/com/harrytmthy/stitch/compiler/BindingGraphValidatorTest.kt
+++ b/stitch-compiler/src/test/kotlin/com/harrytmthy/stitch/compiler/BindingGraphValidatorTest.kt
@@ -144,7 +144,7 @@ class BindingGraphValidatorTest {
         bindings.forEach { providedBindings[it] = it }
         return ContributionScanResult(
             providedBindings = providedBindings,
-            requestedBindingsByModuleKey = emptyMap(),
+            requestedBindings = emptyMap(),
             customScopeByCanonicalName = bindings.mapNotNull { it.scope as? Scope.Custom }
                 .associateBy { it.canonicalName },
             scopeDependencies = emptyMap(),
@@ -163,7 +163,6 @@ class BindingGraphValidatorTest {
             scope = scope,
             location = "$type.kt:1",
             kind = BindingKind.PROVIDED_IN_CONSTRUCTOR,
-            moduleKey = "TEST",
         ).apply {
             this.dependencies = ArrayList(dependencies)
         }


### PR DESCRIPTION
### Summary

This PR removes legacy `moduleKey` usage from contributor metadata and flattens requested binding collection to be grouped directly by requester FQN.

### Implementation Details

The contributor and aggregator models are simplified to match the post-`Part<ModuleKey>` direction:

- `@Contribute` no longer includes `moduleKey`
- `ProvidedBinding` no longer stores `moduleKey`
- `ContributionScanResult` now stores requested bindings as `Map<String, List<RequestedBinding>>`
- `LocalScanResult` now stores local requested bindings under `requestedBindings`
- `ContributionScanner` merges requested bindings directly by requester FQN instead of nesting them under module keys
- related call sites, generators, scanners, and tests are updated accordingly

Closes #139