### PR TITLE
refactor(scope): Decouple scope instantiation from ScopeRef

### DIFF
--- a/stitch/api/stitch.api
+++ b/stitch/api/stitch.api
@@ -13,7 +13,7 @@ public abstract interface class com/harrytmthy/stitch/api/InjectorScope {
 
 public final class com/harrytmthy/stitch/api/Module {
 	public fun <init> (ZLkotlin/jvm/functions/Function1;)V
-	public final fun define (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLcom/harrytmthy/stitch/api/ScopeRef;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
+	public final fun define (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;Lcom/harrytmthy/stitch/internal/DefinitionType;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/harrytmthy/stitch/api/Bindable;
 }
 
 public final class com/harrytmthy/stitch/api/ModuleKt {
@@ -45,26 +45,30 @@ public final class com/harrytmthy/stitch/api/ResolutionContext {
 	public final fun getScope ()Lcom/harrytmthy/stitch/api/Scope;
 }
 
+public final class com/harrytmthy/stitch/api/RetrievableScopeRef : com/harrytmthy/stitch/api/ScopeRef {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun createScope ()Lcom/harrytmthy/stitch/api/Scope;
+}
+
 public final class com/harrytmthy/stitch/api/Scope {
 	public final fun close ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()I
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isOpen ()Z
 	public final fun open ()V
 }
 
 public final class com/harrytmthy/stitch/api/ScopeKt {
-	public static final fun scope (Ljava/lang/String;)Lcom/harrytmthy/stitch/api/ScopeRef;
+	public static final fun scope (Ljava/lang/String;)Lcom/harrytmthy/stitch/api/RetrievableScopeRef;
 }
 
-public final class com/harrytmthy/stitch/api/ScopeRef {
-	public static final field Companion Lcom/harrytmthy/stitch/api/ScopeRef$Companion;
+public abstract class com/harrytmthy/stitch/api/ScopeRef {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun createScope ()Lcom/harrytmthy/stitch/api/Scope;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
-}
-
-public final class com/harrytmthy/stitch/api/ScopeRef$Companion {
-	public final fun of (Ljava/lang/String;)Lcom/harrytmthy/stitch/api/ScopeRef;
 }
 
 public final class com/harrytmthy/stitch/api/Stitch {
@@ -98,6 +102,7 @@ public final class com/harrytmthy/stitch/exception/MissingScopeException : com/h
 }
 
 public final class com/harrytmthy/stitch/exception/ScopeClosedException : com/harrytmthy/stitch/exception/GetFailedException {
+	public fun <init> (Lkotlin/reflect/KClass;Lcom/harrytmthy/stitch/api/Qualifier;I)V
 }
 
 public final class com/harrytmthy/stitch/internal/DefinitionType : java/lang/Enum {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Component.kt
@@ -50,7 +50,7 @@ class Component internal constructor() {
         }
 
         // Resolve once to learn the canonical cache key
-        val node = lookupNode(type, qualifier, scope?.reference)
+        val node = lookupNode(type, qualifier, scope?.name)
 
         // Fast-path: If alias, recheck caches under canonical key
         if (node.type !== type) {
@@ -109,8 +109,8 @@ class Component internal constructor() {
         }
     }
 
-    private fun lookupNode(type: KClass<*>, qualifier: Qualifier?, scopeRef: ScopeRef?): Node {
-        Registry.scopedDefinitions[scopeRef]?.get(type)?.get(qualifier)?.let { return it }
+    private fun lookupNode(type: KClass<*>, qualifier: Qualifier?, scopeName: String?): Node {
+        Registry.scopedDefinitions[scopeName]?.get(type)?.get(qualifier)?.let { return it }
         val inner = Registry.definitions[type] ?: throw MissingBindingException.missingType(type)
         return inner.getOrElse(qualifier) {
             throw MissingBindingException.missingQualifier(type, qualifier, inner.keys)

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Module.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Module.kt
@@ -55,7 +55,7 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
         qualifier: Qualifier? = null,
         noinline factory: ResolutionContext.() -> T,
     ): Bindable {
-        return define(T::class, qualifier, Scoped, false, scopeRef, null, factory)
+        return define(T::class, qualifier, Scoped, false, scopeRef.name, null, factory)
     }
 
     @PublishedApi
@@ -64,7 +64,7 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
         qualifier: Qualifier?,
         definitionType: DefinitionType,
         eager: Boolean,
-        scopeRef: ScopeRef?,
+        scopeName: String?,
         factory: (ResolutionContext.() -> T)?,
         scopedFactory: (ResolutionContext.() -> T)?,
     ): Bindable {
@@ -81,7 +81,7 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
                     }
                 }
 
-            Scoped -> createAndRegisterScopedNode(type, qualifier, scopeRef!!, scopedFactory!!)
+            Scoped -> createAndRegisterScopedNode(type, qualifier, scopeName!!, scopedFactory!!)
                 .also(registeredNodes::add)
         }
     }
@@ -95,14 +95,14 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
         val node = Node(
             type = type,
             qualifier = qualifier,
-            scopeRef = null,
+            scopeName = null,
             definitionType = definitionType,
             factory = factory,
             onBind = ::registerAlias,
         )
         val inner = Registry.definitions.getOrPut(type) { HashMap() }
         if (inner.containsKey(qualifier)) {
-            throw DuplicateBindingException(type, qualifier, scopeRef = null)
+            throw DuplicateBindingException(type, qualifier, scopeName = null)
         }
         inner[qualifier] = node
         return node
@@ -111,28 +111,28 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
     private fun <T : Any> createAndRegisterScopedNode(
         type: KClass<T>,
         qualifier: Qualifier?,
-        scopeRef: ScopeRef,
+        scopeName: String,
         factory: ResolutionContext.() -> T,
     ): Node {
         val node = Node(
             type = type,
             qualifier = qualifier,
-            scopeRef = scopeRef,
+            scopeName = scopeName,
             definitionType = Scoped,
             factory = factory,
             onBind = ::registerAlias,
         )
-        val qualifiersByType = Registry.scopedDefinitions.getOrPut(scopeRef) { HashMap() }
+        val qualifiersByType = Registry.scopedDefinitions.getOrPut(scopeName) { HashMap() }
         val nodeByQualifier = qualifiersByType.getOrPut(type) { HashMap() }
         if (nodeByQualifier.containsKey(qualifier)) {
-            throw DuplicateBindingException(type, qualifier, scopeRef)
+            throw DuplicateBindingException(type, qualifier, scopeName)
         }
         nodeByQualifier[qualifier] = node
         return node
     }
 
     private fun registerAlias(aliasType: KClass<*>, target: Node) {
-        if (target.scopeRef == null) {
+        if (target.scopeName == null) {
             val primary = Registry.definitions[target.type] ?: return
             val existing = Registry.definitions[aliasType]
             check(existing == null || existing === primary) {
@@ -140,7 +140,7 @@ class Module(private val forceEager: Boolean, private val onRegister: Module.() 
             }
             Registry.definitions[aliasType] = primary
         } else {
-            val scopedByType = Registry.scopedDefinitions[target.scopeRef] ?: return
+            val scopedByType = Registry.scopedDefinitions[target.scopeName] ?: return
             val primaryScoped = scopedByType[target.type] ?: return
             val existingScoped = scopedByType[aliasType]
             check(existingScoped == null || existingScoped === primaryScoped) {

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Scope.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Scope.kt
@@ -16,11 +16,12 @@
 
 package com.harrytmthy.stitch.api
 
+import com.harrytmthy.stitch.exception.ScopeClosedException
 import com.harrytmthy.stitch.internal.ConcurrentHashMap
 import com.harrytmthy.stitch.internal.Registry
 import kotlinx.atomicfu.atomic
 
-class Scope internal constructor(internal val id: Int, internal val reference: ScopeRef) {
+class Scope internal constructor(val id: Int, val name: String) {
 
     private val open = atomic(false)
 
@@ -31,56 +32,72 @@ class Scope internal constructor(internal val id: Int, internal val reference: S
     fun close() {
         open.value = false
         Registry.scoped.remove(id)
-        ScopeRef.getScopeIds(reference)?.remove(id)
+        ScopeManager.getScopeIdsByName(name)?.remove(id)
     }
 
-    inline fun <reified T : Any> get(qualifier: Qualifier? = null): T =
-        Stitch.get(qualifier, scope = this)
+    fun isOpen(): Boolean = open.value
+
+    inline fun <reified T : Any> get(qualifier: Qualifier? = null): T {
+        if (!isOpen()) {
+            // Fail-fast: We already have this exception
+            throw ScopeClosedException(T::class, qualifier, id)
+        }
+        val value = Stitch.get<T>(qualifier, scope = this)
+        if (!isOpen()) {
+            throw ScopeClosedException(T::class, qualifier, id)
+        }
+        return value
+    }
 
     inline fun <reified T : Any> inject(qualifier: Qualifier? = null): Lazy<T> =
-        Stitch.inject(qualifier, scope = this)
-
-    internal fun isOpen(): Boolean = open.value
-}
-
-class ScopeRef private constructor(val name: String) {
-
-    private val id = nextId()
+        lazy(LazyThreadSafetyMode.NONE) { get(qualifier) }
 
     override fun hashCode(): Int = id
 
-    override fun equals(other: Any?): Boolean = other is ScopeRef && other.id == this.id
+    override fun equals(other: Any?): Boolean = other is Scope && other.id == this.id
+}
+
+sealed class ScopeRef(val name: String) {
+
+    override fun hashCode(): Int = name.hashCode()
+
+    override fun equals(other: Any?): Boolean = other is ScopeRef && other.name == this.name
+}
+
+class RetrievableScopeRef(name: String) : ScopeRef(name) {
 
     fun createScope(): Scope {
-        val id = nextId()
-        val inner = idsByScopeRef.computeIfAbsent(this) { HashSet() }
+        val id = ScopeManager.nextId()
+        val inner = ScopeManager.idsByScopeName.computeIfAbsent(name) { HashSet() }
         inner.add(id)
-        return Scope(id, reference = this)
-    }
-
-    inline fun <reified T : Any> get(qualifier: Qualifier? = null): T =
-        Stitch.get(qualifier)
-
-    companion object {
-
-        private val pool = ConcurrentHashMap<String, ScopeRef>()
-
-        private val idsByScopeRef = ConcurrentHashMap<ScopeRef, HashSet<Int>>()
-
-        private val nextId = atomic(1)
-
-        fun of(name: String): ScopeRef = pool.computeIfAbsent(name, ::ScopeRef)
-
-        internal fun nextId(): Int = nextId.getAndIncrement()
-
-        internal fun getScopeIds(scopeRef: ScopeRef): HashSet<Int>? = idsByScopeRef[scopeRef]
-
-        internal fun clear() {
-            pool.clear()
-            idsByScopeRef.clear()
-            nextId.value = 1
-        }
+        return Scope(id, name)
     }
 }
 
-fun scope(name: String): ScopeRef = ScopeRef.of(name)
+internal object ScopeManager {
+
+    val pool = ConcurrentHashMap<String, RetrievableScopeRef>()
+
+    val idsByScopeName = ConcurrentHashMap<String, HashSet<Int>>()
+
+    val nextId = atomic(1)
+
+    fun getOrCreate(name: String): RetrievableScopeRef {
+        if (name.isEmpty()) {
+            error("Scope name cannot be empty")
+        }
+        return pool.computeIfAbsent(name, ::RetrievableScopeRef)
+    }
+
+    fun nextId(): Int = nextId.getAndIncrement()
+
+    fun getScopeIdsByName(name: String): HashSet<Int>? = idsByScopeName[name]
+
+    fun clear() {
+        pool.clear()
+        idsByScopeName.clear()
+        nextId.value = 1
+    }
+}
+
+fun scope(name: String): RetrievableScopeRef = ScopeManager.getOrCreate(name)

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/api/Stitch.kt
@@ -70,7 +70,7 @@ object Stitch {
     fun reset() {
         unregisterAll()
         Named.clear()
-        ScopeRef.clear()
+        ScopeManager.clear()
     }
 
     inline fun <reified T : Any> get(qualifier: Qualifier? = null, scope: Scope? = null): T =

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/DuplicateBindingException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/DuplicateBindingException.kt
@@ -17,7 +17,6 @@
 package com.harrytmthy.stitch.exception
 
 import com.harrytmthy.stitch.api.Qualifier
-import com.harrytmthy.stitch.api.ScopeRef
 import kotlin.reflect.KClass
 
 /**
@@ -26,13 +25,11 @@ import kotlin.reflect.KClass
 class DuplicateBindingException internal constructor(
     type: KClass<*>,
     qualifier: Qualifier?,
-    scopeRef: ScopeRef?,
+    scopeName: String?,
 ) : IllegalStateException(
     buildString {
         val qualStr = qualifier?.toString() ?: "<default>"
         append("Duplicate binding for ${type.qualifiedName} / $qualStr")
-        if (scopeRef != null) {
-            append(" / '${scopeRef.name}'")
-        }
+        scopeName?.let { append(" / '$it'") }
     },
 )

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/ScopeClosedException.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/exception/ScopeClosedException.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.KClass
  * - Call `scope.open()` before resolving.
  * - Avoid holding on to references after `scope.close()`.
  */
-class ScopeClosedException internal constructor(
+class ScopeClosedException(
     type: KClass<*>,
     qualifier: Qualifier?,
     scopeId: Int,

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Node.kt
@@ -19,13 +19,12 @@ package com.harrytmthy.stitch.internal
 import com.harrytmthy.stitch.api.Bindable
 import com.harrytmthy.stitch.api.Qualifier
 import com.harrytmthy.stitch.api.ResolutionContext
-import com.harrytmthy.stitch.api.ScopeRef
 import kotlin.reflect.KClass
 
 internal class Node(
     val type: KClass<*>,
     val qualifier: Qualifier?,
-    val scopeRef: ScopeRef?,
+    val scopeName: String?,
     val definitionType: DefinitionType,
     val factory: (ResolutionContext) -> Any,
     val onBind: (KClass<*>, Node) -> Unit,

--- a/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Registry.kt
+++ b/stitch/src/commonMain/kotlin/com/harrytmthy/stitch/internal/Registry.kt
@@ -18,14 +18,14 @@ package com.harrytmthy.stitch.internal
 
 import com.harrytmthy.stitch.api.DefaultQualifier
 import com.harrytmthy.stitch.api.Qualifier
-import com.harrytmthy.stitch.api.ScopeRef
+import com.harrytmthy.stitch.api.ScopeManager
 import kotlin.reflect.KClass
 
 internal object Registry {
 
     val definitions = HashMap<KClass<*>, HashMap<Qualifier?, Node>>()
 
-    val scopedDefinitions = HashMap<ScopeRef, HashMap<KClass<*>, HashMap<Qualifier?, Node>>>()
+    val scopedDefinitions = HashMap<String, HashMap<KClass<*>, HashMap<Qualifier?, Node>>>()
 
     val singletons = ConcurrentHashMap<KClass<*>, ConcurrentHashMap<Qualifier, Any>>()
 
@@ -33,19 +33,19 @@ internal object Registry {
 
     fun remove(nodes: List<Node>) {
         for (node in nodes) {
-            if (node.scopeRef != null) {
-                scopedDefinitions[node.scopeRef]?.let { qualifiersByType ->
+            if (node.scopeName != null) {
+                scopedDefinitions[node.scopeName]?.let { qualifiersByType ->
                     qualifiersByType[node.type]?.let { nodeByQualifier ->
                         nodeByQualifier.remove(node.qualifier)
                         if (nodeByQualifier.isEmpty()) {
                             qualifiersByType.removeFamily(node.type)
                             if (qualifiersByType.isEmpty()) {
-                                scopedDefinitions.remove(node.scopeRef)
+                                scopedDefinitions.remove(node.scopeName)
                             }
                         }
                     }
                 }
-                val scopeIds = ScopeRef.getScopeIds(node.scopeRef) ?: continue
+                val scopeIds = ScopeManager.getScopeIdsByName(node.scopeName) ?: continue
                 val iterator = scopeIds.iterator()
                 while (iterator.hasNext()) {
                     val scopeId = iterator.next()


### PR DESCRIPTION
### Summary

Decouples `ScopeRef` from runtime scope instantiation to unify the DI and SL scope model.

This PR makes `ScopeRef` represent scope identity only, while runtime scope creation is moved into a dedicated `RetrievableScopeRef`. In addition, SL internals are updated to use `scopeName` instead of `ScopeRef` as the registry key for scoped definitions.

### Implementation Details

- Refactors `Scope` to store `id` and `name` directly, removing the old `reference` field.
- Moves runtime scope creation from `ScopeRef` into `RetrievableScopeRef`.
- Introduces `ScopeManager` as the central manager for scope references and active scope IDs.
- Updates `scope(name)` to return `RetrievableScopeRef`.
- Replaces `ScopeRef`-keyed scoped registries with `String`-keyed `scopeName` registries.
- Updates `Component`, `Module`, `Node`, `Registry`, and exception types to use `scopeName` consistently.
- Improves `Scope.get()` with explicit closed-scope fail-fast checks before and after resolution.
- Updates `Stitch.reset()` to clear `ScopeManager` instead of `ScopeRef`.
- Keeps the API aligned with the planned DI path, where generated scope references will extend `ScopeRef` without exposing runtime scope instantiation.

Closes #141